### PR TITLE
Feature/ Swagger 의존성 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     runtimeOnly 'org.postgresql:postgresql'


### PR DESCRIPTION

### 개요

Swagger UI 사용을 위해 springdoc-openapi 의존성을 추가하고 `/swagger-ui.html`에서 API 테스트가 가능하도록 설정함.

### 변경 사항

* springdoc-openapi-starter-webmvc-ui 2.6.0 의존성 추가

### 배포

* develop 브랜치로 정상 병합
