### PR TITLE
Feature/ STS 기반 AWS 계정 검증 로직 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
+	implementation 'software.amazon.awssdk:sts:2.25.65'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     runtimeOnly 'org.postgresql:postgresql'

--- a/src/main/java/com/budgetops/backend/BudgetopsBackendApplication.java
+++ b/src/main/java/com/budgetops/backend/BudgetopsBackendApplication.java
@@ -1,9 +1,9 @@
-package com.example.budgetops_backend;
+package com.budgetops.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
-@SpringBootApplication
+@SpringBootApplication(scanBasePackages = {"com.budgetops.backend"})
 public class BudgetopsBackendApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/budgetops/backend/BudgetopsBackendApplication.java
+++ b/src/main/java/com/budgetops/backend/BudgetopsBackendApplication.java
@@ -2,8 +2,10 @@ package com.budgetops.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication(scanBasePackages = {"com.budgetops.backend"})
+@EnableJpaAuditing
 public class BudgetopsBackendApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/budgetops/backend/aws/controller/AwsAccountController.java
+++ b/src/main/java/com/budgetops/backend/aws/controller/AwsAccountController.java
@@ -2,6 +2,7 @@ package com.budgetops.backend.aws.controller;
 
 import com.budgetops.backend.aws.dto.AwsAccountCreateRequest;
 import com.budgetops.backend.aws.entity.AwsAccount;
+import com.budgetops.backend.aws.dto.AwsAccountResponse;
 import com.budgetops.backend.aws.service.AwsAccountService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -14,10 +15,10 @@ import org.springframework.web.bind.annotation.*;
 public class AwsAccountController {
     private final AwsAccountService service;
 
-    // STS 검증 없이 즉시 저장
+    // STS GetCallerIdentity로 검증 후 저장
     @PostMapping
     public ResponseEntity<?> register(@Valid @RequestBody AwsAccountCreateRequest req) {
-        AwsAccount saved = service.createWithoutVerify(req);
+        AwsAccount saved = service.createWithVerify(req);
         // secret은 응답에서 제외: 최소 정보만 반환
         return ResponseEntity.ok(new Object() {
             public final Long id = saved.getId();
@@ -27,6 +28,32 @@ public class AwsAccountController {
             public final String secretKeyLast4 = "****" + saved.getSecretKeyLast4();
             public final boolean active = Boolean.TRUE.equals(saved.getActive());
         });
+    }
+
+    // 활성 계정 목록
+    @GetMapping
+    public ResponseEntity<?> getActiveAccounts() {
+        return ResponseEntity.ok(service.getActiveAccounts().stream()
+                .map(this::toResp)
+                .toList());
+    }
+
+    // 계정 정보(id 기준)
+    @GetMapping("/{accountId}/info")
+    public ResponseEntity<AwsAccountResponse> getAccountInfo(@PathVariable Long accountId) {
+        AwsAccount a = service.getAccountInfo(accountId);
+        return ResponseEntity.ok(toResp(a));
+    }
+
+    private AwsAccountResponse toResp(AwsAccount a) {
+        return AwsAccountResponse.builder()
+                .id(a.getId())
+                .name(a.getName())
+                .defaultRegion(a.getDefaultRegion())
+                .accessKeyId(a.getAccessKeyId())
+                .secretKeyLast4("****" + a.getSecretKeyLast4())
+                .active(Boolean.TRUE.equals(a.getActive()))
+                .build();
     }
 }
 

--- a/src/main/java/com/budgetops/backend/aws/controller/AwsAccountController.java
+++ b/src/main/java/com/budgetops/backend/aws/controller/AwsAccountController.java
@@ -45,6 +45,13 @@ public class AwsAccountController {
         return ResponseEntity.ok(toResp(a));
     }
 
+    // 계정 비활성(삭제 대용): 참조 무결성 보존을 위해 active=false 처리
+    @DeleteMapping("/{accountId}")
+    public ResponseEntity<Void> deleteAccount(@PathVariable Long accountId) {
+        service.deactivateAccount(accountId);
+        return ResponseEntity.noContent().build();
+    }
+
     private AwsAccountResponse toResp(AwsAccount a) {
         return AwsAccountResponse.builder()
                 .id(a.getId())

--- a/src/main/java/com/budgetops/backend/aws/controller/AwsResourceController.java
+++ b/src/main/java/com/budgetops/backend/aws/controller/AwsResourceController.java
@@ -1,0 +1,37 @@
+package com.budgetops.backend.aws.controller;
+
+import com.budgetops.backend.aws.entity.AwsResource;
+import com.budgetops.backend.aws.service.AwsResourceQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/aws")
+@RequiredArgsConstructor
+public class AwsResourceController {
+
+    private final AwsResourceQueryService service;
+
+    // 특정 계정의 모든 리소스
+    @GetMapping("/accounts/{accountId}/resources")
+    public ResponseEntity<List<AwsResource>> byAccount(@PathVariable Long accountId) {
+        return ResponseEntity.ok(service.findByAccount(accountId));
+    }
+
+    // 리소스 타입별 조회
+    @GetMapping("/resources")
+    public ResponseEntity<List<AwsResource>> byType(@RequestParam String resourceType) {
+        return ResponseEntity.ok(service.findByType(resourceType));
+    }
+
+    // 계정 + 타입 조회
+    @GetMapping("/accounts/{accountId}/resources/{resourceType}")
+    public ResponseEntity<List<AwsResource>> byAccountAndType(@PathVariable Long accountId, @PathVariable String resourceType) {
+        return ResponseEntity.ok(service.findByAccountAndType(accountId, resourceType));
+    }
+}
+
+

--- a/src/main/java/com/budgetops/backend/aws/dto/AwsAccountResponse.java
+++ b/src/main/java/com/budgetops/backend/aws/dto/AwsAccountResponse.java
@@ -1,0 +1,17 @@
+package com.budgetops.backend.aws.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AwsAccountResponse {
+    private Long id;
+    private String name;
+    private String defaultRegion;
+    private String accessKeyId;
+    private String secretKeyLast4;
+    private boolean active;
+}
+
+

--- a/src/main/java/com/budgetops/backend/aws/repository/AwsAccountRepository.java
+++ b/src/main/java/com/budgetops/backend/aws/repository/AwsAccountRepository.java
@@ -3,8 +3,10 @@ package com.budgetops.backend.aws.repository;
 import com.budgetops.backend.aws.entity.AwsAccount;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface AwsAccountRepository extends JpaRepository<AwsAccount, Long> {
     Optional<AwsAccount> findByAccessKeyId(String accessKeyId);
+    List<AwsAccount> findByActiveTrue();
 }

--- a/src/main/java/com/budgetops/backend/aws/service/AwsAccountService.java
+++ b/src/main/java/com/budgetops/backend/aws/service/AwsAccountService.java
@@ -56,6 +56,16 @@ public class AwsAccountService {
         return accountRepo.findById(accountId)
                 .orElseThrow(() -> new ResponseStatusException(NOT_FOUND, "계정을 찾을 수 없습니다."));
     }
+
+    @Transactional
+    public void deactivateAccount(Long accountId) {
+        AwsAccount account = accountRepo.findById(accountId)
+                .orElseThrow(() -> new ResponseStatusException(NOT_FOUND, "계정을 찾을 수 없습니다."));
+        if (Boolean.TRUE.equals(account.getActive())) {
+            account.setActive(Boolean.FALSE);
+            accountRepo.save(account);
+        }
+    }
 }
 
 

--- a/src/main/java/com/budgetops/backend/aws/service/AwsAccountService.java
+++ b/src/main/java/com/budgetops/backend/aws/service/AwsAccountService.java
@@ -4,6 +4,7 @@ import com.budgetops.backend.aws.dto.AwsAccountCreateRequest;
 import com.budgetops.backend.aws.entity.AwsAccount;
 import com.budgetops.backend.aws.repository.AwsAccountRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;

--- a/src/main/java/com/budgetops/backend/aws/service/AwsAccountService.java
+++ b/src/main/java/com/budgetops/backend/aws/service/AwsAccountService.java
@@ -6,17 +6,33 @@ import com.budgetops.backend.aws.repository.AwsAccountRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+
+import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor
 public class AwsAccountService {
     private final AwsAccountRepository accountRepo;
+    private final AwsCredentialValidator credentialValidator;
+
+    @Value("${app.aws.validate:true}")
+    private boolean validate;
 
     @Transactional
-    public AwsAccount createWithoutVerify(AwsAccountCreateRequest req) {
+    public AwsAccount createWithVerify(AwsAccountCreateRequest req) {
         accountRepo.findByAccessKeyId(req.getAccessKeyId()).ifPresent(a -> {
             throw new IllegalArgumentException("이미 등록된 accessKeyId 입니다.");
         });
+
+        if (validate) {
+            boolean ok = credentialValidator.isValid(req.getAccessKeyId(), req.getSecretAccessKey(), req.getDefaultRegion());
+            if (!ok) {
+                throw new IllegalArgumentException("AWS 자격증명이 유효하지 않습니다.");
+            }
+        }
 
         AwsAccount a = new AwsAccount();
         a.setName(req.getName());
@@ -27,6 +43,17 @@ public class AwsAccountService {
         a.setSecretKeyLast4(sk.substring(Math.max(0, sk.length() - 4)));
         a.setActive(Boolean.TRUE); // 등록 즉시 활성
         return accountRepo.save(a);
+    }
+
+    @Transactional(readOnly = true)
+    public List<AwsAccount> getActiveAccounts() {
+        return accountRepo.findByActiveTrue();
+    }
+
+    @Transactional(readOnly = true)
+    public AwsAccount getAccountInfo(Long accountId) {
+        return accountRepo.findById(accountId)
+                .orElseThrow(() -> new ResponseStatusException(NOT_FOUND, "계정을 찾을 수 없습니다."));
     }
 }
 

--- a/src/main/java/com/budgetops/backend/aws/service/AwsCredentialValidator.java
+++ b/src/main/java/com/budgetops/backend/aws/service/AwsCredentialValidator.java
@@ -1,0 +1,33 @@
+package com.budgetops.backend.aws.service;
+
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.model.GetCallerIdentityRequest;
+
+import java.time.Duration;
+
+@Component
+public class AwsCredentialValidator {
+    public boolean isValid(String accessKeyId, String secretAccessKey, String region) {
+        try {
+            var creds = AwsBasicCredentials.create(accessKeyId, secretAccessKey);
+            try (StsClient sts = StsClient.builder()
+                    .region(region != null ? Region.of(region) : Region.AWS_GLOBAL)
+                    .credentialsProvider(StaticCredentialsProvider.create(creds))
+                    .overrideConfiguration(c -> c
+                            .apiCallTimeout(Duration.ofSeconds(5))
+                            .apiCallAttemptTimeout(Duration.ofSeconds(5)))
+                    .build()) {
+                sts.getCallerIdentity(GetCallerIdentityRequest.builder().build());
+                return true;
+            }
+        } catch (Exception ex) {
+            return false;
+        }
+    }
+}
+
+

--- a/src/main/java/com/budgetops/backend/aws/service/AwsResourceQueryService.java
+++ b/src/main/java/com/budgetops/backend/aws/service/AwsResourceQueryService.java
@@ -1,0 +1,32 @@
+package com.budgetops.backend.aws.service;
+
+import com.budgetops.backend.aws.entity.AwsResource;
+import com.budgetops.backend.aws.repository.AwsResourceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AwsResourceQueryService {
+    private final AwsResourceRepository resourceRepository;
+
+    @Transactional(readOnly = true)
+    public List<AwsResource> findByAccount(Long accountId) {
+        return resourceRepository.findByAwsAccountId(accountId);
+    }
+
+    @Transactional(readOnly = true)
+    public List<AwsResource> findByType(String resourceType) {
+        return resourceRepository.findByResourceType(resourceType);
+    }
+
+    @Transactional(readOnly = true)
+    public List<AwsResource> findByAccountAndType(Long accountId, String resourceType) {
+        return resourceRepository.findByAwsAccountIdAndResourceType(accountId, resourceType);
+    }
+}
+
+

--- a/src/main/java/com/budgetops/backend/config/WebConfig.java
+++ b/src/main/java/com/budgetops/backend/config/WebConfig.java
@@ -14,7 +14,7 @@ public class WebConfig {
       @Override
       public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-          .allowedOrigins("http://localhost:5173", "https://*.vercel.app")
+          .allowedOrigins("http://localhost:3000", "http://localhost:5173", "https://*.vercel.app")
           .allowedMethods("GET","POST","PUT","DELETE","PATCH","OPTIONS")
           .allowCredentials(true);
       }

--- a/src/main/java/com/budgetops/backend/config/WebCorsConfig.java
+++ b/src/main/java/com/budgetops/backend/config/WebCorsConfig.java
@@ -14,7 +14,7 @@ public class WebCorsConfig {
             @Override
             public void addCorsMappings(CorsRegistry registry) {
                 registry.addMapping("/**")
-                        .allowedOrigins("https://budgetops.work")
+                        .allowedOrigins("http://localhost:3000", "https://budgetops.work")
                         .allowedMethods("GET","POST","PUT","PATCH","DELETE","OPTIONS")
                         .allowedHeaders("*")
                         .allowCredentials(true);

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,4 +1,6 @@
 spring:
+  main:
+    allow-bean-definition-overriding: true
   datasource:
     url: jdbc:h2:mem:budgetops;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
     driver-class-name: org.h2.Driver
@@ -20,4 +22,12 @@ server:
 app:
   crypto:
     key: ${APP_CRED_KEY:}
+  aws:
+    validate: false
+
+springdoc:
+  api-docs:
+    enabled: true
+  packages-to-scan: com.budgetops.backend
+  paths-to-match: /api/**
 


### PR DESCRIPTION
### 개요

AWS 계정 등록 시 STS(Security Token Service)를 활용해 실제 자격증명 유효성을 검증하는 로직을 백엔드에 추가함.
또한 계정/리소스 조회 API와 DTO, 환경 설정 등을 확장하여 AWS 계정 관리 기능을 완성도 있게 구축함.

### 변경 사항

* STS 기반 AWS 자격증명 검증 컴포넌트(`AwsCredentialValidator`) 추가
* 로컬 개발 환경에서 검증 스킵 옵션(`app.aws.validate=false`) 지원
* AWS 계정 조회 API(목록/단건) 추가
* AWS 리소스 조회 서비스 및 컨트롤러 확장

  * 계정별 / 타입별 / 계정+타입별 조회
* 민감정보 제거 및 마스킹 포함한 `AwsAccountResponse` DTO 추가
* springdoc/validation/STS 의존성 정리
* 패키지 스캔 및 민감키 기본값 제거로 보안 강화
* CORS 수정
* 계정 비활성화 API 및 서비스 로직 추가
* JPA Auditing 활성화

### 배포

* 정상적으로 검증 및 병합됨
* PR은 별도 merge 없이 기능 통합 후 close 처리됨
