### PR TITLE
Feature/8 계정별 EC2 인스턴스 조회 API 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
+	implementation 'software.amazon.awssdk:sts:2.25.65'
+	implementation 'software.amazon.awssdk:ec2:2.25.65'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     runtimeOnly 'org.postgresql:postgresql'

--- a/build.gradle
+++ b/build.gradle
@@ -28,9 +28,7 @@ dependencies {
 	implementation 'software.amazon.awssdk:ec2:2.25.65'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-    runtimeOnly 'org.postgresql:postgresql'
-    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
-    runtimeOnly("org.postgresql:postgresql:42.7.4")
+	runtimeOnly("org.postgresql:postgresql:42.7.4")
 
 	// Lombok
 	compileOnly 'org.projectlombok:lombok:1.18.34'

--- a/src/main/java/com/budgetops/backend/aws/controller/AwsEc2Controller.java
+++ b/src/main/java/com/budgetops/backend/aws/controller/AwsEc2Controller.java
@@ -1,0 +1,31 @@
+package com.budgetops.backend.aws.controller;
+
+import com.budgetops.backend.aws.dto.AwsEc2InstanceResponse;
+import com.budgetops.backend.aws.service.AwsEc2Service;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/aws/accounts")
+@RequiredArgsConstructor
+public class AwsEc2Controller {
+
+    private final AwsEc2Service ec2Service;
+
+    @GetMapping("/{accountId}/ec2/instances")
+    public ResponseEntity<List<AwsEc2InstanceResponse>> listInstances(
+            @PathVariable Long accountId,
+            @RequestParam(value = "region", required = false) String regionOverride
+    ) {
+        List<AwsEc2InstanceResponse> instances = ec2Service.listInstances(accountId, regionOverride);
+        return ResponseEntity.ok(instances);
+    }
+}
+

--- a/src/main/java/com/budgetops/backend/aws/dto/AwsEc2InstanceResponse.java
+++ b/src/main/java/com/budgetops/backend/aws/dto/AwsEc2InstanceResponse.java
@@ -1,0 +1,18 @@
+package com.budgetops.backend.aws.dto;
+
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+public class AwsEc2InstanceResponse {
+    String instanceId;
+    String name;
+    String instanceType;
+    String state;
+    String availabilityZone;
+    String publicIp;
+    String privateIp;
+    String launchTime;
+}
+

--- a/src/main/java/com/budgetops/backend/aws/service/AwsEc2Service.java
+++ b/src/main/java/com/budgetops/backend/aws/service/AwsEc2Service.java
@@ -1,0 +1,108 @@
+package com.budgetops.backend.aws.service;
+
+import com.budgetops.backend.aws.dto.AwsEc2InstanceResponse;
+import com.budgetops.backend.aws.entity.AwsAccount;
+import com.budgetops.backend.aws.repository.AwsAccountRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.exception.SdkException;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.ec2.Ec2Client;
+import software.amazon.awssdk.services.ec2.model.DescribeInstancesRequest;
+import software.amazon.awssdk.services.ec2.model.Instance;
+import software.amazon.awssdk.services.ec2.model.Tag;
+
+import java.time.Duration;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+@Service
+@RequiredArgsConstructor
+public class AwsEc2Service {
+    private static final DateTimeFormatter ISO_FORMATTER = DateTimeFormatter.ISO_INSTANT;
+
+    private final AwsAccountRepository accountRepository;
+
+    @Transactional(readOnly = true)
+    public List<AwsEc2InstanceResponse> listInstances(Long accountId, String regionOverride) {
+        AwsAccount account = accountRepository.findById(accountId)
+                .orElseThrow(() -> new ResponseStatusException(NOT_FOUND, "계정을 찾을 수 없습니다."));
+
+        String accessKeyId = account.getAccessKeyId();
+        String secretAccessKey = account.getSecretKeyEnc();
+        if (accessKeyId == null || secretAccessKey == null) {
+            throw new ResponseStatusException(NOT_FOUND, "계정 자격 증명이 존재하지 않습니다.");
+        }
+
+        String effectiveRegion = (regionOverride != null && !regionOverride.isBlank())
+                ? regionOverride
+                : account.getDefaultRegion();
+        Region region = resolveRegion(effectiveRegion);
+
+        try (Ec2Client ec2 = Ec2Client.builder()
+                .region(region)
+                .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKeyId, secretAccessKey)))
+                .overrideConfiguration(c -> c
+                        .apiCallAttemptTimeout(Duration.ofSeconds(10))
+                        .apiCallTimeout(Duration.ofSeconds(30)))
+                .build()) {
+
+            return ec2.describeInstancesPaginator(DescribeInstancesRequest.builder().build())
+                    .reservations().stream()
+                    .flatMap(reservation -> reservation.instances().stream())
+                    .map(this::toResponse)
+                    .toList();
+
+        } catch (SdkException ex) {
+            throw new ResponseStatusException(INTERNAL_SERVER_ERROR, "EC2 인스턴스 정보를 조회하지 못했습니다.", ex);
+        }
+    }
+
+    private Region resolveRegion(String region) {
+        if (region == null || region.isBlank()) {
+            return Region.US_EAST_1;
+        }
+        try {
+            return Region.of(region);
+        } catch (IllegalArgumentException ex) {
+            throw new ResponseStatusException(BAD_REQUEST, "지원하지 않는 AWS Region 입니다: " + region, ex);
+        }
+    }
+
+    private AwsEc2InstanceResponse toResponse(Instance instance) {
+        return AwsEc2InstanceResponse.builder()
+                .instanceId(instance.instanceId())
+                .name(extractNameTag(instance))
+                .instanceType(instance.instanceTypeAsString())
+                .state(instance.state() != null ? instance.state().nameAsString() : null)
+                .availabilityZone(instance.placement() != null ? instance.placement().availabilityZone() : null)
+                .publicIp(instance.publicIpAddress())
+                .privateIp(instance.privateIpAddress())
+                .launchTime(Optional.ofNullable(instance.launchTime())
+                        .map(ISO_FORMATTER::format)
+                        .orElse(null))
+                .build();
+    }
+
+    private String extractNameTag(Instance instance) {
+        if (instance.tags() == null) {
+            return null;
+        }
+        return instance.tags().stream()
+                .filter(tag -> "Name".equalsIgnoreCase(tag.key()))
+                .map(Tag::value)
+                .findFirst()
+                .orElse(null);
+    }
+}
+


### PR DESCRIPTION
### 개요

AWS 계정별 EC2 인스턴스를 조회하는 API를 추가하여, 사용자가 등록한 계정으로 실시간 EC2 목록을 가져올 수 있도록 구현함.

### 변경 사항

* `AwsEc2InstanceResponse` DTO 추가
* EC2 인스턴스 조회 서비스 구현(AWS SDK 호출)
* 리전 오버라이드(region 파라미터) 및 유효성 검증 추가
* 예외 처리 추가

  * 400: 잘못된 리전
  * 404: 자격증명 없음
  * 500: SDK 오류
* `AwsEc2Controller` 추가

  * `GET /api/aws/accounts/{id}/ec2/instances`
  * `region` 쿼리 파라미터 지원

### 배포

* develop 브랜치로 정상 병합
