### PR TITLE
Feature/AWS 메트릭 조회 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ dependencies {
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
 	implementation 'software.amazon.awssdk:sts:2.25.65'
 	implementation 'software.amazon.awssdk:ec2:2.25.65'
+	implementation 'software.amazon.awssdk:cloudwatch:2.25.65'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/com/budgetops/backend/aws/controller/AwsEc2Controller.java
+++ b/src/main/java/com/budgetops/backend/aws/controller/AwsEc2Controller.java
@@ -1,6 +1,7 @@
 package com.budgetops.backend.aws.controller;
 
 import com.budgetops.backend.aws.dto.AwsEc2InstanceResponse;
+import com.budgetops.backend.aws.dto.AwsEc2MetricsResponse;
 import com.budgetops.backend.aws.service.AwsEc2Service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -36,6 +37,17 @@ public class AwsEc2Controller {
     ) {
         AwsEc2InstanceResponse instance = ec2Service.getEc2Instance(accountId, instanceId, regionOverride);
         return ResponseEntity.ok(instance);
+    }
+
+    @GetMapping("/{accountId}/ec2/instances/{instanceId}/metrics")
+    public ResponseEntity<AwsEc2MetricsResponse> getInstanceMetrics(
+            @PathVariable Long accountId,
+            @PathVariable String instanceId,
+            @RequestParam(value = "region", required = false) String regionOverride,
+            @RequestParam(value = "hours", required = false, defaultValue = "1") Integer hours
+    ) {
+        AwsEc2MetricsResponse metrics = ec2Service.getInstanceMetrics(accountId, instanceId, regionOverride, hours);
+        return ResponseEntity.ok(metrics);
     }
 }
 

--- a/src/main/java/com/budgetops/backend/aws/dto/AwsEc2MetricsResponse.java
+++ b/src/main/java/com/budgetops/backend/aws/dto/AwsEc2MetricsResponse.java
@@ -1,0 +1,25 @@
+package com.budgetops.backend.aws.dto;
+
+import lombok.Builder;
+import lombok.Value;
+import java.util.List;
+
+@Value
+@Builder
+public class AwsEc2MetricsResponse {
+    String instanceId;
+    String region;
+    List<MetricDataPoint> cpuUtilization;
+    List<MetricDataPoint> networkIn;
+    List<MetricDataPoint> networkOut;
+    List<MetricDataPoint> memoryUtilization; // CloudWatch Agent가 설치된 경우에만 사용 가능
+    
+    @Value
+    @Builder
+    public static class MetricDataPoint {
+        String timestamp;
+        Double value;
+        String unit; // Percent, Bytes, Bytes/Second 등
+    }
+}
+

--- a/src/main/java/com/budgetops/backend/aws/service/AwsEc2Service.java
+++ b/src/main/java/com/budgetops/backend/aws/service/AwsEc2Service.java
@@ -271,7 +271,7 @@ public class AwsEc2Service {
         // Name 태그 찾기
         String name = instance.tags().stream()
                 .filter(tag -> "Name".equals(tag.key()))
-                .map(Tag::value)
+                .map(software.amazon.awssdk.services.ec2.model.Tag::value)
                 .findFirst()
                 .orElse("");
         

--- a/src/main/java/com/budgetops/backend/aws/service/AwsEc2Service.java
+++ b/src/main/java/com/budgetops/backend/aws/service/AwsEc2Service.java
@@ -1,6 +1,7 @@
 package com.budgetops.backend.aws.service;
 
 import com.budgetops.backend.aws.dto.AwsEc2InstanceResponse;
+import com.budgetops.backend.aws.dto.AwsEc2MetricsResponse;
 import com.budgetops.backend.aws.entity.AwsAccount;
 import com.budgetops.backend.aws.repository.AwsAccountRepository;
 import lombok.RequiredArgsConstructor;
@@ -10,11 +11,16 @@ import org.springframework.web.server.ResponseStatusException;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.cloudwatch.CloudWatchClient;
+import software.amazon.awssdk.services.cloudwatch.model.*;
 import software.amazon.awssdk.services.ec2.Ec2Client;
 import software.amazon.awssdk.services.ec2.model.*;
 
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 
@@ -102,6 +108,145 @@ public class AwsEc2Service {
             log.error("Failed to fetch EC2 instance {}: {}", instanceId, e.awsErrorDetails().errorMessage());
             throw new RuntimeException("EC2 인스턴스 조회 실패: " + e.awsErrorDetails().errorMessage());
         }
+    }
+    
+    /**
+     * EC2 인스턴스의 CloudWatch 메트릭 조회
+     * 
+     * @param accountId AWS 계정 ID
+     * @param instanceId EC2 인스턴스 ID
+     * @param region 리전 (null이면 계정의 기본 리전)
+     * @param hours 조회할 시간 범위 (기본값: 1시간)
+     * @return 메트릭 데이터 (CPU, NetworkIn, NetworkOut, MemoryUtilization)
+     */
+    public AwsEc2MetricsResponse getInstanceMetrics(Long accountId, String instanceId, String region, Integer hours) {
+        AwsAccount account = accountRepository.findById(accountId)
+                .orElseThrow(() -> new ResponseStatusException(NOT_FOUND, "AWS 계정을 찾을 수 없습니다."));
+        
+        if (!Boolean.TRUE.equals(account.getActive())) {
+            throw new IllegalStateException("비활성화된 계정입니다.");
+        }
+        
+        String targetRegion = region != null ? region : account.getDefaultRegion();
+        if (targetRegion == null) {
+            targetRegion = "us-east-1";
+        }
+        
+        int hoursToQuery = hours != null && hours > 0 ? hours : 1;
+        Instant endTime = Instant.now();
+        Instant startTime = endTime.minus(hoursToQuery, ChronoUnit.HOURS);
+        
+        log.info("Fetching metrics for EC2 instance {} in region {} for the last {} hours", 
+                instanceId, targetRegion, hoursToQuery);
+        
+        try (CloudWatchClient cloudWatchClient = createCloudWatchClient(account, targetRegion)) {
+            // CPU Utilization
+            List<AwsEc2MetricsResponse.MetricDataPoint> cpuMetrics = getMetricStatistics(
+                    cloudWatchClient, instanceId, "CPUUtilization", "Percent", startTime, endTime);
+            
+            // Network In
+            List<AwsEc2MetricsResponse.MetricDataPoint> networkInMetrics = getMetricStatistics(
+                    cloudWatchClient, instanceId, "NetworkIn", "Bytes", startTime, endTime);
+            
+            // Network Out
+            List<AwsEc2MetricsResponse.MetricDataPoint> networkOutMetrics = getMetricStatistics(
+                    cloudWatchClient, instanceId, "NetworkOut", "Bytes", startTime, endTime);
+            
+            // Memory Utilization (CloudWatch Agent가 설치된 경우에만 사용 가능)
+            List<AwsEc2MetricsResponse.MetricDataPoint> memoryMetrics = getMetricStatisticsWithNamespace(
+                    cloudWatchClient, instanceId, "CWAgent", "mem_used_percent", "Percent", startTime, endTime);
+            
+            return AwsEc2MetricsResponse.builder()
+                    .instanceId(instanceId)
+                    .region(targetRegion)
+                    .cpuUtilization(cpuMetrics)
+                    .networkIn(networkInMetrics)
+                    .networkOut(networkOutMetrics)
+                    .memoryUtilization(memoryMetrics)
+                    .build();
+            
+        } catch (CloudWatchException e) {
+            log.error("Failed to fetch CloudWatch metrics for instance {}: {}", 
+                    instanceId, e.awsErrorDetails().errorMessage());
+            throw new RuntimeException("메트릭 조회 실패: " + e.awsErrorDetails().errorMessage());
+        } catch (Exception e) {
+            log.error("Unexpected error while fetching metrics for instance {}", instanceId, e);
+            throw new RuntimeException("메트릭 조회 중 오류 발생: " + e.getMessage());
+        }
+    }
+    
+    /**
+     * CloudWatch에서 특정 메트릭의 통계 데이터 조회 (AWS/EC2 네임스페이스)
+     */
+    private List<AwsEc2MetricsResponse.MetricDataPoint> getMetricStatistics(
+            CloudWatchClient cloudWatchClient,
+            String instanceId,
+            String metricName,
+            String unit,
+            Instant startTime,
+            Instant endTime) {
+        return getMetricStatisticsWithNamespace(
+                cloudWatchClient, instanceId, "AWS/EC2", metricName, unit, startTime, endTime);
+    }
+    
+    /**
+     * CloudWatch에서 특정 메트릭의 통계 데이터 조회 (네임스페이스 지정 가능)
+     */
+    private List<AwsEc2MetricsResponse.MetricDataPoint> getMetricStatisticsWithNamespace(
+            CloudWatchClient cloudWatchClient,
+            String instanceId,
+            String namespace,
+            String metricName,
+            String unit,
+            Instant startTime,
+            Instant endTime) {
+        
+        try {
+            GetMetricStatisticsRequest request = GetMetricStatisticsRequest.builder()
+                    .namespace(namespace)
+                    .metricName(metricName)
+                    .dimensions(Dimension.builder()
+                            .name("InstanceId")
+                            .value(instanceId)
+                            .build())
+                    .startTime(startTime)
+                    .endTime(endTime)
+                    .period(300) // 5분 간격
+                    .statistics(Statistic.AVERAGE)
+                    .build();
+            
+            GetMetricStatisticsResponse response = cloudWatchClient.getMetricStatistics(request);
+            
+            return response.datapoints().stream()
+                    .map(datapoint -> AwsEc2MetricsResponse.MetricDataPoint.builder()
+                            .timestamp(datapoint.timestamp().toString())
+                            .value(datapoint.average())
+                            .unit(unit)
+                            .build())
+                    .sorted((a, b) -> a.getTimestamp().compareTo(b.getTimestamp()))
+                    .collect(Collectors.toList());
+                    
+        } catch (CloudWatchException e) {
+            // 메트릭이 없는 경우 (예: MemoryUtilization은 CloudWatch Agent 필요)
+            log.warn("Metric {} in namespace {} not available for instance {}: {}", 
+                    metricName, namespace, instanceId, e.awsErrorDetails().errorMessage());
+            return new ArrayList<>();
+        }
+    }
+    
+    /**
+     * CloudWatch 클라이언트 생성
+     */
+    private CloudWatchClient createCloudWatchClient(AwsAccount account, String region) {
+        AwsBasicCredentials credentials = AwsBasicCredentials.create(
+                account.getAccessKeyId(),
+                account.getSecretKeyEnc() // 암호화된 값이 자동으로 복호화됨
+        );
+        
+        return CloudWatchClient.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(credentials))
+                .build();
     }
     
     /**


### PR DESCRIPTION
## Feature/AWS 메트릭 조회 기능 구현

### 개요
AWS EC2 인스턴스의 주요 CloudWatch 메트릭(CPU, Memory, Network In/Out)을 조회하는 기능을 추가함.

### 주요 구현 내용
- CloudWatch SDK 의존성 추가  
  software.amazon.awssdk:cloudwatch:2.25.65 적용

- 메트릭 응답 DTO 추가  
  AwsEc2MetricsResponse:  
  CPUUtilization, MemoryUtilization, NetworkIn, NetworkOut 데이터 포인트 포함

- 서비스 로직 구현  
  AwsEc2Service.getInstanceMetrics 메서드 추가  
  CloudWatch에서 아래 메트릭 조회  
  - CPUUtilization  
  - NetworkIn  
  - NetworkOut  
  - MemoryUtilization(CloudWatch Agent 필요)

- API 엔드포인트 추가  
  GET `/api/aws/accounts/{accountId}/ec2/instances/{instanceId}/metrics`  
  파라미터: region(Optional), hours(Optional, 기본 1시간)

### 사용 예시
- `/metrics` 기본 1시간 조회  
- `/metrics?hours=24`  
- `/metrics?region=us-west-2&hours=6`
