### PR TITLE
Feature/AWS 프리티어 한도·사용량 수집 및 Rightsizing 시뮬레이션 추가

### DIFF
--- a/src/main/java/com/budgetops/backend/aws/constants/FreeTierLimits.java
+++ b/src/main/java/com/budgetops/backend/aws/constants/FreeTierLimits.java
@@ -1,0 +1,118 @@
+package com.budgetops.backend.aws.constants;
+
+import java.util.Map;
+
+/**
+ * AWS 프리티어 한도 정보
+ * 각 서비스별 프리티어 한도를 정의합니다.
+ */
+public class FreeTierLimits {
+    
+    /**
+     * EC2 프리티어 한도
+     * - t2.micro, t3.micro, t4g.micro 인스턴스 타입
+     * - 월 750시간 무료
+     */
+    public static final double EC2_FREE_TIER_HOURS_PER_MONTH = 750.0;
+    
+    /**
+     * S3 프리티어 한도
+     * - 스토리지: 5GB
+     * - PUT 요청: 20,000건
+     * - GET 요청: 20,000건
+     */
+    public static final double S3_FREE_TIER_STORAGE_GB = 5.0;
+    public static final long S3_FREE_TIER_PUT_REQUESTS = 20000L;
+    public static final long S3_FREE_TIER_GET_REQUESTS = 20000L;
+    
+    /**
+     * RDS 프리티어 한도
+     * - db.t2.micro, db.t3.micro 인스턴스 타입
+     * - 월 750시간 무료
+     * - 스토리지: 20GB
+     */
+    public static final double RDS_FREE_TIER_HOURS_PER_MONTH = 750.0;
+    public static final double RDS_FREE_TIER_STORAGE_GB = 20.0;
+    
+    /**
+     * Lambda 프리티어 한도
+     * - 요청: 월 1,000,000건
+     * - 컴퓨팅 시간: 월 400,000 GB-초
+     */
+    public static final long LAMBDA_FREE_TIER_REQUESTS = 1000000L;
+    public static final long LAMBDA_FREE_TIER_COMPUTE_GB_SECONDS = 400000L;
+    
+    /**
+     * 데이터 전송 프리티어 한도
+     * - 아웃바운드: 월 1GB (첫 12개월)
+     * - 인바운드: 무제한
+     */
+    public static final double DATA_TRANSFER_OUT_FREE_TIER_GB = 1.0;
+    
+    /**
+     * EC2 인스턴스 타입별 시간당 요금 (USD)
+     * 프리티어 초과 시 적용되는 요금
+     */
+    public static final Map<String, Double> EC2_INSTANCE_PRICING = Map.of(
+        "t2.micro", 0.0116,
+        "t3.micro", 0.0104,
+        "t4g.micro", 0.0084,
+        "t2.small", 0.023,
+        "t3.small", 0.0208,
+        "t4g.small", 0.0168
+    );
+    
+    /**
+     * 서비스별 프리티어 한도 확인
+     */
+    public static boolean isFreeTierEligible(String service, String resourceType, double usage) {
+        return switch (service.toUpperCase()) {
+            case "EC2" -> usage <= EC2_FREE_TIER_HOURS_PER_MONTH;
+            case "S3" -> resourceType != null && resourceType.equals("STORAGE") 
+                ? usage <= S3_FREE_TIER_STORAGE_GB 
+                : true; // 요청 수는 별도로 확인 필요
+            case "RDS" -> usage <= RDS_FREE_TIER_HOURS_PER_MONTH;
+            case "LAMBDA" -> resourceType != null && resourceType.equals("REQUESTS")
+                ? usage <= LAMBDA_FREE_TIER_REQUESTS
+                : usage <= LAMBDA_FREE_TIER_COMPUTE_GB_SECONDS;
+            default -> false;
+        };
+    }
+    
+    /**
+     * EC2 인스턴스 타입이 프리티어 대상인지 확인
+     */
+    public static boolean isFreeTierInstanceType(String instanceType) {
+        if (instanceType == null) return false;
+        String lowerType = instanceType.toLowerCase();
+        return lowerType.equals("t2.micro") || 
+               lowerType.equals("t3.micro") || 
+               lowerType.equals("t4g.micro");
+    }
+    
+    /**
+     * 프리티어 초과 시 예상 비용 계산 (EC2)
+     */
+    public static double calculateEstimatedCostIfExceeded(String service, String resourceType, 
+                                                          double usage, String instanceType) {
+        if (!isFreeTierEligible(service, resourceType, usage)) {
+            double freeTierLimit = switch (service.toUpperCase()) {
+                case "EC2" -> EC2_FREE_TIER_HOURS_PER_MONTH;
+                case "S3" -> S3_FREE_TIER_STORAGE_GB;
+                case "RDS" -> RDS_FREE_TIER_HOURS_PER_MONTH;
+                default -> 0.0;
+            };
+            
+            double exceededUsage = usage - freeTierLimit;
+            
+            if (service.equalsIgnoreCase("EC2") && instanceType != null) {
+                Double hourlyRate = EC2_INSTANCE_PRICING.get(instanceType.toLowerCase());
+                if (hourlyRate != null) {
+                    return exceededUsage * hourlyRate;
+                }
+            }
+        }
+        return 0.0;
+    }
+}
+

--- a/src/main/java/com/budgetops/backend/aws/service/AwsUsageService.java
+++ b/src/main/java/com/budgetops/backend/aws/service/AwsUsageService.java
@@ -1,0 +1,225 @@
+package com.budgetops.backend.aws.service;
+
+import com.budgetops.backend.aws.constants.FreeTierLimits;
+import com.budgetops.backend.aws.entity.AwsAccount;
+import com.budgetops.backend.aws.repository.AwsAccountRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.cloudwatch.CloudWatchClient;
+import software.amazon.awssdk.services.cloudwatch.model.*;
+import software.amazon.awssdk.services.ec2.Ec2Client;
+import software.amazon.awssdk.services.ec2.model.*;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+/**
+ * AWS 사용량 및 프리티어 정보를 수집하는 서비스
+ * CloudWatch와 EC2 API를 활용하여 실제 사용량을 추적합니다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AwsUsageService {
+    
+    private final AwsAccountRepository accountRepository;
+    
+    /**
+     * EC2 인스턴스의 실제 실행 시간 계산 (프리티어 범위 내 사용량 추적)
+     * 
+     * @param accountId AWS 계정 ID
+     * @param startDate 시작 날짜
+     * @param endDate 종료 날짜
+     * @return 서비스별 사용량 정보
+     */
+    public List<ServiceUsage> getEc2Usage(Long accountId, String startDate, String endDate) {
+        AwsAccount account = accountRepository.findById(accountId)
+                .orElseThrow(() -> new ResponseStatusException(NOT_FOUND, "AWS 계정을 찾을 수 없습니다."));
+        
+        if (!Boolean.TRUE.equals(account.getActive())) {
+            throw new IllegalStateException("비활성화된 계정입니다.");
+        }
+        
+        String region = account.getDefaultRegion() != null ? account.getDefaultRegion() : "us-east-1";
+        
+        log.info("Fetching EC2 usage for account {} from {} to {}", accountId, startDate, endDate);
+        
+        List<ServiceUsage> usageList = new ArrayList<>();
+        
+        try (Ec2Client ec2Client = createEc2Client(account, region)) {
+            DescribeInstancesRequest request = DescribeInstancesRequest.builder().build();
+            DescribeInstancesResponse response = ec2Client.describeInstances(request);
+            
+            LocalDate start = LocalDate.parse(startDate);
+            LocalDate end = LocalDate.parse(endDate);
+            long daysBetween = ChronoUnit.DAYS.between(start, end);
+            
+            // 모든 인스턴스 수집
+            List<Instance> allInstances = new ArrayList<>();
+            for (Reservation reservation : response.reservations()) {
+                allInstances.addAll(reservation.instances());
+            }
+            
+            // 프리티어 대상 인스턴스만 필터링
+            Map<String, Double> instanceTypeHours = new HashMap<>();
+            
+            for (Instance instance : allInstances) {
+                String instanceType = instance.instanceTypeAsString();
+                
+                if (FreeTierLimits.isFreeTierInstanceType(instanceType)) {
+                    // 실행 시간 계산
+                    Instant launchTime = instance.launchTime();
+                    Instant now = Instant.now();
+                    Instant periodStart = start.atStartOfDay(ZoneId.systemDefault()).toInstant();
+                    Instant periodEnd = end.atStartOfDay(ZoneId.systemDefault()).toInstant();
+                    
+                    // 기간 내 실행 시간 계산
+                    Instant actualStart = launchTime.isAfter(periodStart) ? launchTime : periodStart;
+                    Instant actualEnd = now.isBefore(periodEnd) ? now : periodEnd;
+                    
+                    if (actualStart.isBefore(actualEnd) && 
+                        (instance.state().name() == InstanceStateName.RUNNING || 
+                         instance.state().name() == InstanceStateName.STOPPED)) {
+                        
+                        // 실행 중인 경우에만 시간 계산
+                        if (instance.state().name() == InstanceStateName.RUNNING) {
+                            long hours = ChronoUnit.HOURS.between(actualStart, actualEnd);
+                            if (hours > 0) {
+                                instanceTypeHours.merge(instanceType, (double) hours, Double::sum);
+                            }
+                        }
+                    }
+                }
+            }
+            
+            // 서비스별 사용량으로 변환
+            double totalHours = instanceTypeHours.values().stream()
+                    .mapToDouble(Double::doubleValue)
+                    .sum();
+            
+            if (totalHours > 0) {
+                usageList.add(new ServiceUsage(
+                    "EC2",
+                    totalHours,
+                    FreeTierLimits.EC2_FREE_TIER_HOURS_PER_MONTH,
+                    totalHours <= FreeTierLimits.EC2_FREE_TIER_HOURS_PER_MONTH,
+                    instanceTypeHours
+                ));
+            }
+            
+        } catch (Exception e) {
+            log.error("Failed to fetch EC2 usage for account {}: {}", accountId, e.getMessage(), e);
+            // 에러 발생 시 빈 리스트 반환
+        }
+        
+        return usageList;
+    }
+    
+    /**
+     * CloudWatch를 사용하여 실제 사용량 메트릭 수집
+     * 
+     * @param accountId AWS 계정 ID
+     * @param service 서비스명 (EC2, S3, RDS 등)
+     * @param startDate 시작 날짜
+     * @param endDate 종료 날짜
+     * @return 사용량 메트릭
+     */
+    public UsageMetrics getUsageMetrics(Long accountId, String service, String startDate, String endDate) {
+        AwsAccount account = accountRepository.findById(accountId)
+                .orElseThrow(() -> new ResponseStatusException(NOT_FOUND, "AWS 계정을 찾을 수 없습니다."));
+        
+        if (!Boolean.TRUE.equals(account.getActive())) {
+            throw new IllegalStateException("비활성화된 계정입니다.");
+        }
+        
+        String region = account.getDefaultRegion() != null ? account.getDefaultRegion() : "us-east-1";
+        
+        try (CloudWatchClient cloudWatchClient = createCloudWatchClient(account, region)) {
+            Instant start = LocalDate.parse(startDate).atStartOfDay(ZoneId.systemDefault()).toInstant();
+            Instant end = LocalDate.parse(endDate).atStartOfDay(ZoneId.systemDefault()).toInstant();
+            
+            // 서비스별 메트릭 수집
+            Map<String, Double> metrics = new HashMap<>();
+            
+            if ("EC2".equalsIgnoreCase(service)) {
+                // EC2 인스턴스 실행 시간 집계
+                GetMetricStatisticsRequest request = GetMetricStatisticsRequest.builder()
+                        .namespace("AWS/EC2")
+                        .metricName("CPUUtilization")
+                        .startTime(start)
+                        .endTime(end)
+                        .period(3600) // 1시간 단위
+                        .statistics(Statistic.SAMPLE_COUNT)
+                        .build();
+                
+                GetMetricStatisticsResponse response = cloudWatchClient.getMetricStatistics(request);
+                
+                // 메트릭 데이터 처리
+                if (response.datapoints() != null && !response.datapoints().isEmpty()) {
+                    double totalSamples = response.datapoints().stream()
+                            .mapToDouble(Datapoint::sampleCount)
+                            .sum();
+                    metrics.put("instanceHours", totalSamples);
+                }
+            }
+            
+            return new UsageMetrics(service, metrics);
+            
+        } catch (Exception e) {
+            log.error("Failed to fetch usage metrics for service {}: {}", service, e.getMessage(), e);
+            return new UsageMetrics(service, new HashMap<>());
+        }
+    }
+    
+    private Ec2Client createEc2Client(AwsAccount account, String region) {
+        AwsBasicCredentials credentials = AwsBasicCredentials.create(
+                account.getAccessKeyId(),
+                account.getSecretKeyEnc()
+        );
+        
+        return Ec2Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(credentials))
+                .build();
+    }
+    
+    private CloudWatchClient createCloudWatchClient(AwsAccount account, String region) {
+        AwsBasicCredentials credentials = AwsBasicCredentials.create(
+                account.getAccessKeyId(),
+                account.getSecretKeyEnc()
+        );
+        
+        return CloudWatchClient.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(credentials))
+                .build();
+    }
+    
+    // DTO 클래스들
+    public record ServiceUsage(
+        String service,
+        double usage,
+        double freeTierLimit,
+        boolean isWithinFreeTier,
+        Map<String, Double> details
+    ) {}
+    
+    public record UsageMetrics(
+        String service,
+        Map<String, Double> metrics
+    ) {}
+}
+


### PR DESCRIPTION
## Feature/AWS 프리티어 한도·사용량 수집 및 Rightsizing 시뮬레이션 추가

### 개요  
AWS 프리티어 무료 한도 및 실제 사용량을 자동으로 수집하는 기능과, Rightsizing 시뮬레이션 기능을 RecommendationService에 확장하여 비용 최적화 정확도를 향상함.

### 주요 내용  
- AWS 프리티어 사용량·한도 정보를 조회하고 계정별로 기록하는 기능 추가  
- RecommendationService에 Rightsizing 시뮬레이션 로직 구현  
- 시나리오 이름 다국어(ko/en) 지원  
- 프리티어 사용량 기반 절감 가능 영역 식별 기능 강화  

### 기대 효과  
- 프리티어 초과 비용을 사전 감지  
- 리소스 스펙 다운/업 권장 근거 강화  
- 국제 사용자 및 다국어 환경 대응성 향상