### PR TITLE
Feature/GCP 계정 삭제 시 리소스 정리 로직 추가

### DIFF
--- a/src/main/java/com/budgetops/backend/gcp/service/GcpAccountService.java
+++ b/src/main/java/com/budgetops/backend/gcp/service/GcpAccountService.java
@@ -4,6 +4,7 @@ import com.budgetops.backend.gcp.dto.*;
 import com.google.auth.oauth2.ServiceAccountCredentials;
 import com.budgetops.backend.gcp.entity.GcpAccount;
 import com.budgetops.backend.gcp.repository.GcpAccountRepository;
+import com.budgetops.backend.gcp.repository.GcpResourceRepository;
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.BigQueryOptions;
 import com.google.cloud.bigquery.Dataset;
@@ -30,13 +31,16 @@ public class GcpAccountService {
     private final GcpServiceAccountVerifier serviceAccountVerifier;
     private final GcpBillingAccountVerifier billingVerifier;
     private final GcpAccountRepository gcpAccountRepository;
+    private final GcpResourceRepository gcpResourceRepository;
 
     public GcpAccountService(GcpServiceAccountVerifier serviceAccountVerifier,
                              GcpBillingAccountVerifier billingVerifier,
-                             GcpAccountRepository gcpAccountRepository) {
+                             GcpAccountRepository gcpAccountRepository,
+                             GcpResourceRepository gcpResourceRepository) {
         this.serviceAccountVerifier = serviceAccountVerifier;
         this.billingVerifier = billingVerifier;
         this.gcpAccountRepository = gcpAccountRepository;
+        this.gcpResourceRepository = gcpResourceRepository;
     }
 
     public void setServiceAccountId(ServiceAccountIdRequest request) {
@@ -148,6 +152,13 @@ public class GcpAccountService {
     public void deleteAccount(Long id) {
         GcpAccount account = gcpAccountRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("GCP 계정을 찾을 수 없습니다."));
+        
+        // 계정에 연결된 모든 리소스를 먼저 삭제 (외래키 제약조건 해결)
+        gcpResourceRepository.findByGcpAccountId(id).forEach(resource -> {
+            gcpResourceRepository.delete(resource);
+        });
+        
+        // 리소스 삭제 후 계정 삭제
         gcpAccountRepository.delete(account);
     }
 


### PR DESCRIPTION
## Feature/GCP 계정 삭제 시 리소스 정리 로직 추가

### 개요
GCP 계정 삭제 시 해당 계정에 속한 리소스가 데이터베이스에 남아 누적되던 문제를 해결하기 위해, **계정 삭제와 동시에 관련 리소스를 정리하는 안전한 삭제 흐름을 구현함**.

### 주요 내용
- GcpAccountService에 `GcpResourceRepository` 의존성 추가
- 계정 삭제 시 리소스 테이블에서 해당 계정의 모든 리소스 기록 일괄 삭제
- 데이터 일관성 보장을 위한 삭제 순서 및 예외 처리 정비

### 기대 효과
- GCP 리소스 데이터 누적 방지
- 계정·리소스 간 참조 무결성 확보
- 리소스 조회/추천/시뮬레이션 로직의 정확성 향상
