### PR TITLE
feat: NCP (Naver Cloud Platform) 백엔드 지원 추가

### DIFF
--- a/src/main/java/com/budgetops/backend/ncp/client/NcpApiClient.java
+++ b/src/main/java/com/budgetops/backend/ncp/client/NcpApiClient.java
@@ -1,0 +1,139 @@
+package com.budgetops.backend.ncp.client;
+
+import com.budgetops.backend.ncp.service.NcpSignatureGenerator;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.*;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpStatusCodeException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.Map;
+
+@Slf4j
+@Component
+public class NcpApiClient {
+
+    private static final String SERVER_API_BASE_URL = "https://ncloud.apigw.ntruss.com";
+    private static final String BILLING_API_BASE_URL = "https://billingapi.apigw.ntruss.com/billing/v1";
+
+    private final NcpSignatureGenerator signatureGenerator;
+    private final ObjectMapper objectMapper;
+    private final RestTemplate restTemplate;
+
+    public NcpApiClient(NcpSignatureGenerator signatureGenerator,
+                        ObjectMapper objectMapper,
+                        RestTemplateBuilder builder) {
+        this.signatureGenerator = signatureGenerator;
+        this.objectMapper = objectMapper;
+        this.restTemplate = builder.build();
+    }
+
+    /**
+     * Server API 호출
+     */
+    public JsonNode callServerApi(String path, Map<String, String> params, String accessKey, String secretKey) {
+        String url = SERVER_API_BASE_URL + path;
+        return get(url, params, accessKey, secretKey);
+    }
+
+    /**
+     * Billing API 호출
+     */
+    public JsonNode callBillingApi(String path, Map<String, String> params, String accessKey, String secretKey) {
+        String url = BILLING_API_BASE_URL + path;
+        return get(url, params, accessKey, secretKey);
+    }
+
+    /**
+     * GET 요청
+     */
+    private JsonNode get(String baseUrl, Map<String, String> params, String accessKey, String secretKey) {
+        String timestamp = String.valueOf(System.currentTimeMillis());
+
+        // URL with query parameters
+        String fullUrl = withQueryParams(baseUrl, params);
+
+        // URL path만 추출 (시그니처 생성용)
+        String urlPath = fullUrl.substring(fullUrl.indexOf("/", 8)); // https:// 이후 첫 / 부터
+
+        // 시그니처 생성
+        String signature = signatureGenerator.generateSignature("GET", urlPath, timestamp, accessKey, secretKey);
+
+        // 헤더 설정
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("x-ncp-apigw-timestamp", timestamp);
+        headers.set("x-ncp-iam-access-key", accessKey);
+        headers.set("x-ncp-apigw-signature-v2", signature);
+
+        try {
+            ResponseEntity<String> response = restTemplate.exchange(
+                    fullUrl,
+                    HttpMethod.GET,
+                    new HttpEntity<>(headers),
+                    String.class
+            );
+            return objectMapper.readTree(response.getBody());
+        } catch (HttpStatusCodeException e) {
+            log.error("NCP GET 호출 실패: url={}, status={}, body={}", fullUrl, e.getStatusCode(), e.getResponseBodyAsString());
+            throw new IllegalStateException("NCP API 호출 실패: " + e.getStatusCode() + " " + e.getResponseBodyAsString(), e);
+        } catch (Exception e) {
+            log.error("NCP GET 호출 중 알 수 없는 오류: url={}", fullUrl, e);
+            throw new IllegalStateException("NCP API 호출 중 오류가 발생했습니다: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * POST 요청
+     */
+    private JsonNode post(String baseUrl, Map<String, String> params, Object body, String accessKey, String secretKey) {
+        String timestamp = String.valueOf(System.currentTimeMillis());
+
+        // URL with query parameters
+        String fullUrl = withQueryParams(baseUrl, params);
+
+        // URL path만 추출 (시그니처 생성용)
+        String urlPath = fullUrl.substring(fullUrl.indexOf("/", 8));
+
+        // 시그니처 생성
+        String signature = signatureGenerator.generateSignature("POST", urlPath, timestamp, accessKey, secretKey);
+
+        // 헤더 설정
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("x-ncp-apigw-timestamp", timestamp);
+        headers.set("x-ncp-iam-access-key", accessKey);
+        headers.set("x-ncp-apigw-signature-v2", signature);
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        try {
+            ResponseEntity<String> response = restTemplate.exchange(
+                    fullUrl,
+                    HttpMethod.POST,
+                    new HttpEntity<>(body, headers),
+                    String.class
+            );
+            return objectMapper.readTree(response.getBody());
+        } catch (HttpStatusCodeException e) {
+            log.error("NCP POST 호출 실패: url={}, status={}, body={}", fullUrl, e.getStatusCode(), e.getResponseBodyAsString());
+            throw new IllegalStateException("NCP API 호출 실패: " + e.getStatusCode() + " " + e.getResponseBodyAsString(), e);
+        } catch (Exception e) {
+            log.error("NCP POST 호출 중 알 수 없는 오류: url={}", fullUrl, e);
+            throw new IllegalStateException("NCP API 호출 중 오류가 발생했습니다: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * URL에 쿼리 파라미터 추가
+     */
+    private String withQueryParams(String url, Map<String, String> params) {
+        if (params == null || params.isEmpty()) {
+            return url;
+        }
+        UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(url);
+        params.forEach(builder::queryParam);
+        return builder.toUriString();
+    }
+}

--- a/src/main/java/com/budgetops/backend/ncp/controller/NcpAccountController.java
+++ b/src/main/java/com/budgetops/backend/ncp/controller/NcpAccountController.java
@@ -1,0 +1,126 @@
+package com.budgetops.backend.ncp.controller;
+
+import com.budgetops.backend.ncp.dto.NcpAccountCreateRequest;
+import com.budgetops.backend.ncp.dto.NcpAccountResponse;
+import com.budgetops.backend.ncp.dto.NcpDailyUsage;
+import com.budgetops.backend.ncp.dto.NcpMonthlyCost;
+import com.budgetops.backend.ncp.entity.NcpAccount;
+import com.budgetops.backend.ncp.service.NcpAccountService;
+import com.budgetops.backend.ncp.service.NcpCostService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/ncp/accounts")
+@RequiredArgsConstructor
+public class NcpAccountController {
+    private final NcpAccountService service;
+    private final NcpCostService costService;
+
+    /**
+     * NCP 계정 등록 (자격증명 검증 후 저장)
+     */
+    @PostMapping
+    public ResponseEntity<?> register(@Valid @RequestBody NcpAccountCreateRequest req) {
+        NcpAccount saved = service.createWithVerify(req);
+        // secret은 응답에서 제외: 최소 정보만 반환
+        return ResponseEntity.ok(new Object() {
+            public final Long id = saved.getId();
+            public final String name = saved.getName();
+            public final String regionCode = saved.getRegionCode();
+            public final String accessKey = saved.getAccessKey();
+            public final String secretKeyLast4 = "****" + saved.getSecretKeyLast4();
+            public final boolean active = Boolean.TRUE.equals(saved.getActive());
+        });
+    }
+
+    /**
+     * 활성 계정 목록 조회
+     */
+    @GetMapping
+    public ResponseEntity<?> getActiveAccounts() {
+        return ResponseEntity.ok(service.getActiveAccounts().stream()
+                .map(this::toResp)
+                .toList());
+    }
+
+    /**
+     * 계정 정보 조회 (id 기준)
+     */
+    @GetMapping("/{accountId}/info")
+    public ResponseEntity<NcpAccountResponse> getAccountInfo(@PathVariable Long accountId) {
+        NcpAccount a = service.getAccountInfo(accountId);
+        return ResponseEntity.ok(toResp(a));
+    }
+
+    /**
+     * 계정 비활성화 (삭제 대용)
+     */
+    @DeleteMapping("/{accountId}")
+    public ResponseEntity<Void> deleteAccount(@PathVariable Long accountId) {
+        service.deactivateAccount(accountId);
+        return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * 특정 계정의 월별 비용 조회
+     */
+    @GetMapping("/{accountId}/costs")
+    public ResponseEntity<List<NcpMonthlyCost>> getAccountCosts(
+            @PathVariable Long accountId,
+            @RequestParam(required = false) String startMonth,
+            @RequestParam(required = false) String endMonth
+    ) {
+        // 기본값: 최근 3개월
+        if (startMonth == null) {
+            startMonth = LocalDate.now().minusMonths(2).format(DateTimeFormatter.ofPattern("yyyyMM"));
+        }
+        if (endMonth == null) {
+            endMonth = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMM"));
+        }
+
+        List<NcpMonthlyCost> costs = costService.getCosts(accountId, startMonth, endMonth);
+        return ResponseEntity.ok(costs);
+    }
+
+    /**
+     * 특정 계정의 일별 사용량 조회
+     */
+    @GetMapping("/{accountId}/usage/daily")
+    public ResponseEntity<List<NcpDailyUsage>> getAccountDailyUsage(
+            @PathVariable Long accountId,
+            @RequestParam(required = false) String startDay,
+            @RequestParam(required = false) String endDay
+    ) {
+        // 기본값: 이번 달 1일 ~ 오늘
+        if (startDay == null) {
+            startDay = LocalDate.now().withDayOfMonth(1).format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+        }
+        if (endDay == null) {
+            endDay = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+        }
+
+        List<NcpDailyUsage> usageList = costService.getDailyUsage(accountId, startDay, endDay);
+        return ResponseEntity.ok(usageList);
+    }
+
+    /**
+     * Entity를 Response DTO로 변환
+     */
+    private NcpAccountResponse toResp(NcpAccount a) {
+        return NcpAccountResponse.builder()
+                .id(a.getId())
+                .name(a.getName())
+                .regionCode(a.getRegionCode())
+                .accessKey(a.getAccessKey())
+                .secretKeyLast4("****" + a.getSecretKeyLast4())
+                .active(Boolean.TRUE.equals(a.getActive()))
+                .build();
+    }
+}

--- a/src/main/java/com/budgetops/backend/ncp/controller/NcpServerController.java
+++ b/src/main/java/com/budgetops/backend/ncp/controller/NcpServerController.java
@@ -1,0 +1,55 @@
+package com.budgetops.backend.ncp.controller;
+
+import com.budgetops.backend.ncp.dto.NcpServerInstanceResponse;
+import com.budgetops.backend.ncp.service.NcpServerService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/ncp/accounts")
+@RequiredArgsConstructor
+public class NcpServerController {
+
+    private final NcpServerService serverService;
+
+    /**
+     * 서버 인스턴스 목록 조회
+     */
+    @GetMapping("/{accountId}/servers/instances")
+    public ResponseEntity<List<NcpServerInstanceResponse>> listInstances(
+            @PathVariable Long accountId,
+            @RequestParam(value = "regionCode", required = false) String regionCode
+    ) {
+        List<NcpServerInstanceResponse> instances = serverService.listInstances(accountId, regionCode);
+        return ResponseEntity.ok(instances);
+    }
+
+    /**
+     * 서버 인스턴스 시작
+     */
+    @PostMapping("/{accountId}/servers/instances/start")
+    public ResponseEntity<List<NcpServerInstanceResponse>> startInstances(
+            @PathVariable Long accountId,
+            @RequestBody List<String> serverInstanceNos,
+            @RequestParam(value = "regionCode", required = false) String regionCode
+    ) {
+        List<NcpServerInstanceResponse> instances = serverService.startInstances(accountId, serverInstanceNos, regionCode);
+        return ResponseEntity.ok(instances);
+    }
+
+    /**
+     * 서버 인스턴스 정지
+     */
+    @PostMapping("/{accountId}/servers/instances/stop")
+    public ResponseEntity<List<NcpServerInstanceResponse>> stopInstances(
+            @PathVariable Long accountId,
+            @RequestBody List<String> serverInstanceNos,
+            @RequestParam(value = "regionCode", required = false) String regionCode
+    ) {
+        List<NcpServerInstanceResponse> instances = serverService.stopInstances(accountId, serverInstanceNos, regionCode);
+        return ResponseEntity.ok(instances);
+    }
+}

--- a/src/main/java/com/budgetops/backend/ncp/dto/NcpAccountCreateRequest.java
+++ b/src/main/java/com/budgetops/backend/ncp/dto/NcpAccountCreateRequest.java
@@ -1,0 +1,25 @@
+package com.budgetops.backend.ncp.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class NcpAccountCreateRequest {
+    @NotBlank
+    private String name;
+
+    private String regionCode; // KR, JP, US 등 (optional)
+
+    @NotBlank
+    @Size(min = 10, max = 64)
+    private String accessKey;
+
+    @NotBlank
+    @Size(min = 10, max = 128)
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+    private String secretKey;
+}

--- a/src/main/java/com/budgetops/backend/ncp/dto/NcpAccountResponse.java
+++ b/src/main/java/com/budgetops/backend/ncp/dto/NcpAccountResponse.java
@@ -1,0 +1,17 @@
+package com.budgetops.backend.ncp.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class NcpAccountResponse {
+    private Long id;
+    private String name;
+    private String regionCode;
+    private String accessKey;
+    private String secretKeyLast4;
+    private boolean active;
+}

--- a/src/main/java/com/budgetops/backend/ncp/dto/NcpDailyUsage.java
+++ b/src/main/java/com/budgetops/backend/ncp/dto/NcpDailyUsage.java
@@ -1,0 +1,19 @@
+package com.budgetops.backend.ncp.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class NcpDailyUsage {
+    private String useDate; // YYYYMMDD 형식
+    private String contractNo;
+    private String instanceName;
+    private String contractType; // SVR, STG 등
+    private String productItemKind; // Server, Storage 등
+    private Double usageQuantity; // 사용량
+    private String unit; // 단위 코드 (USAGE_SEC 등)
+    private String regionCode;
+}

--- a/src/main/java/com/budgetops/backend/ncp/dto/NcpMonthlyCost.java
+++ b/src/main/java/com/budgetops/backend/ncp/dto/NcpMonthlyCost.java
@@ -1,0 +1,21 @@
+package com.budgetops.backend.ncp.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class NcpMonthlyCost {
+    private String demandMonth; // YYYYMM 형식
+    private String demandType;
+    private String demandTypeDetail;
+    private String contractNo;
+    private String instanceName;
+    private Double demandAmount; // 청구 금액
+    private Double useAmount; // 사용 금액
+    private Double promotionDiscountAmount; // 프로모션 할인
+    private Double etcDiscountAmount; // 기타 할인
+    private String currency; // KRW, USD 등
+}

--- a/src/main/java/com/budgetops/backend/ncp/dto/NcpServerInstanceResponse.java
+++ b/src/main/java/com/budgetops/backend/ncp/dto/NcpServerInstanceResponse.java
@@ -1,0 +1,29 @@
+package com.budgetops.backend.ncp.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class NcpServerInstanceResponse {
+    private String serverInstanceNo;
+    private String serverName;
+    private String serverDescription;
+    private Integer cpuCount;
+    private Long memorySize;
+    private String platformType;
+    private String publicIp;
+    private String privateIp;
+    private String serverInstanceStatus; // INIT, CREAT, RUN, NSTOP
+    private String serverInstanceStatusName; // running, stopped 등
+    private String createDate;
+    private String uptime;
+    private String serverImageProductCode;
+    private String serverProductCode;
+    private String zoneCode;
+    private String regionCode;
+    private String vpcNo;
+    private String subnetNo;
+}

--- a/src/main/java/com/budgetops/backend/ncp/entity/NcpAccount.java
+++ b/src/main/java/com/budgetops/backend/ncp/entity/NcpAccount.java
@@ -1,0 +1,35 @@
+package com.budgetops.backend.ncp.entity;
+
+import com.budgetops.backend.aws.support.CryptoStringConverter;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Table(name = "ncp_account", uniqueConstraints = {
+        @UniqueConstraint(name = "uk_ncp_access_key", columnNames = "accessKey")
+})
+@Getter
+@Setter
+public class NcpAccount {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false, length = 64)
+    private String accessKey;
+
+    // DB에는 암호문만 저장
+    @Convert(converter = CryptoStringConverter.class)
+    @Column(nullable = false, length = 2048)
+    private String secretKeyEnc;
+
+    private String secretKeyLast4;   // 마스킹용
+
+    private String regionCode; // KR, JP, US 등
+
+    private Boolean active = Boolean.TRUE; // 등록 즉시 활성
+}

--- a/src/main/java/com/budgetops/backend/ncp/repository/NcpAccountRepository.java
+++ b/src/main/java/com/budgetops/backend/ncp/repository/NcpAccountRepository.java
@@ -1,0 +1,12 @@
+package com.budgetops.backend.ncp.repository;
+
+import com.budgetops.backend.ncp.entity.NcpAccount;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface NcpAccountRepository extends JpaRepository<NcpAccount, Long> {
+    Optional<NcpAccount> findByAccessKey(String accessKey);
+    List<NcpAccount> findByActiveTrue();
+}

--- a/src/main/java/com/budgetops/backend/ncp/service/NcpAccountService.java
+++ b/src/main/java/com/budgetops/backend/ncp/service/NcpAccountService.java
@@ -1,0 +1,135 @@
+package com.budgetops.backend.ncp.service;
+
+import com.budgetops.backend.ncp.dto.NcpAccountCreateRequest;
+import com.budgetops.backend.ncp.entity.NcpAccount;
+import com.budgetops.backend.ncp.repository.NcpAccountRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NcpAccountService {
+    private final NcpAccountRepository accountRepo;
+    private final NcpCredentialValidator credentialValidator;
+
+    @Value("${app.ncp.validate:true}")
+    private boolean validate;
+
+    @Transactional
+    public NcpAccount createWithVerify(NcpAccountCreateRequest req) {
+        // 입력값 trim
+        String accessKey = req.getAccessKey() != null ? req.getAccessKey().trim() : null;
+        String secretKey = req.getSecretKey() != null ? req.getSecretKey().trim() : null;
+        String name = req.getName() != null ? req.getName().trim() : null;
+        String regionCode = req.getRegionCode() != null ? req.getRegionCode().trim() : null;
+
+        log.info("Creating NCP account with accessKey: {}", accessKey);
+
+        // 기존 계정이 있는지 확인 (활성/비활성 모두 포함)
+        var existingAccount = accountRepo.findByAccessKey(accessKey);
+
+        if (existingAccount.isPresent()) {
+            NcpAccount account = existingAccount.get();
+            log.info("Found existing account with id: {}, active: {}", account.getId(), account.getActive());
+
+            // 활성 계정이면 오류
+            if (Boolean.TRUE.equals(account.getActive())) {
+                log.warn("Attempt to register already active account with accessKey: {}", accessKey);
+                throw new IllegalArgumentException("이미 등록된 accessKey 입니다.");
+            }
+
+            // 비활성 계정이면 재활성화 및 정보 업데이트
+            log.info("Reactivating inactive account with id: {}", account.getId());
+
+            if (validate) {
+                boolean ok = credentialValidator.isValid(accessKey, secretKey, regionCode);
+                if (!ok) {
+                    log.error("Invalid NCP credentials for accessKey: {}", accessKey);
+                    throw new IllegalArgumentException("NCP 자격증명이 유효하지 않습니다.");
+                }
+            }
+
+            // 계정 정보 업데이트
+            account.setName(name);
+            account.setRegionCode(regionCode);
+            account.setSecretKeyEnc(secretKey); // @Convert에 의해 암호화 저장
+            account.setSecretKeyLast4(secretKey.substring(Math.max(0, secretKey.length() - 4)));
+            account.setActive(Boolean.TRUE); // 재활성화
+
+            NcpAccount saved = accountRepo.save(account);
+            log.info("Successfully reactivated account with id: {}, name: {}, active: {}, regionCode: {}",
+                    saved.getId(), saved.getName(), saved.getActive(), saved.getRegionCode());
+
+            // 재활성화 후 즉시 활성 상태 확인
+            NcpAccount verifyAccount = accountRepo.findById(saved.getId()).orElse(null);
+            if (verifyAccount != null) {
+                log.info("Verification: Account {} is now active: {}", verifyAccount.getId(), verifyAccount.getActive());
+            }
+
+            return saved;
+        }
+
+        // 새 계정 생성
+        log.info("Creating new NCP account with accessKey: {}", accessKey);
+
+        if (validate) {
+            boolean ok = credentialValidator.isValid(accessKey, secretKey, regionCode);
+            if (!ok) {
+                log.error("Invalid NCP credentials for new account with accessKey: {}", accessKey);
+                throw new IllegalArgumentException("NCP 자격증명이 유효하지 않습니다.");
+            }
+        }
+
+        NcpAccount a = new NcpAccount();
+        a.setName(name);
+        a.setRegionCode(regionCode);
+        a.setAccessKey(accessKey);
+        a.setSecretKeyEnc(secretKey); // @Convert에 의해 암호화 저장
+        a.setSecretKeyLast4(secretKey.substring(Math.max(0, secretKey.length() - 4)));
+        a.setActive(Boolean.TRUE); // 등록 즉시 활성
+
+        NcpAccount saved = accountRepo.save(a);
+        log.info("Successfully created new account with id: {}", saved.getId());
+        return saved;
+    }
+
+    @Transactional(readOnly = true)
+    public List<NcpAccount> getActiveAccounts() {
+        return accountRepo.findByActiveTrue();
+    }
+
+    @Transactional(readOnly = true)
+    public NcpAccount getAccountInfo(Long accountId) {
+        return accountRepo.findById(accountId)
+                .orElseThrow(() -> new ResponseStatusException(NOT_FOUND, "계정을 찾을 수 없습니다."));
+    }
+
+    @Transactional
+    public void deactivateAccount(Long accountId) {
+        log.info("Deactivating NCP account with id: {}", accountId);
+
+        NcpAccount account = accountRepo.findById(accountId)
+                .orElseThrow(() -> {
+                    log.error("Account not found with id: {}", accountId);
+                    return new ResponseStatusException(NOT_FOUND, "계정을 찾을 수 없습니다.");
+                });
+
+        if (Boolean.TRUE.equals(account.getActive())) {
+            account.setActive(Boolean.FALSE);
+            accountRepo.save(account);
+            log.info("Successfully deactivated account with id: {}, accessKey: {}",
+                    accountId, account.getAccessKey());
+        } else {
+            log.warn("Account with id: {} is already inactive", accountId);
+        }
+    }
+}

--- a/src/main/java/com/budgetops/backend/ncp/service/NcpCostService.java
+++ b/src/main/java/com/budgetops/backend/ncp/service/NcpCostService.java
@@ -1,0 +1,244 @@
+package com.budgetops.backend.ncp.service;
+
+import com.budgetops.backend.ncp.client.NcpApiClient;
+import com.budgetops.backend.ncp.dto.NcpDailyUsage;
+import com.budgetops.backend.ncp.dto.NcpMonthlyCost;
+import com.budgetops.backend.ncp.entity.NcpAccount;
+import com.budgetops.backend.ncp.repository.NcpAccountRepository;
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NcpCostService {
+
+    private static final String RESPONSE_FORMAT_JSON = "json";
+    private static final String ERROR_MSG_ACCOUNT_NOT_FOUND = "NCP 계정을 찾을 수 없습니다.";
+    private static final String ERROR_MSG_INACTIVE_ACCOUNT = "비활성화된 계정입니다.";
+
+    private final NcpAccountRepository accountRepository;
+    private final NcpApiClient apiClient;
+
+    /**
+     * NCP 계정의 월별 비용 조회
+     *
+     * @param accountId NCP 계정 ID
+     * @param startMonth 시작 월 (YYYYMM 형식, 예: 202401)
+     * @param endMonth 종료 월 (YYYYMM 형식, 예: 202403)
+     * @return 월별 비용 목록
+     */
+    public List<NcpMonthlyCost> getCosts(Long accountId, String startMonth, String endMonth) {
+        NcpAccount account = validateAndGetAccount(accountId);
+        log.info("Fetching NCP costs for account {} from {} to {}", accountId, startMonth, endMonth);
+
+        try {
+            Map<String, String> params = buildMonthlyParams(startMonth, endMonth);
+            JsonNode response = apiClient.callBillingApi(
+                    "/cost/getContractDemandCostList",
+                    params,
+                    account.getAccessKey(),
+                    account.getSecretKeyEnc()
+            );
+
+            List<NcpMonthlyCost> costs = parseContractDemandCostList(response);
+            log.info("Found {} cost records for account {} from {} to {}", costs.size(), accountId, startMonth, endMonth);
+            return costs;
+
+        } catch (Exception e) {
+            log.error("Failed to fetch costs for account {} from {} to {}: {}", accountId, startMonth, endMonth, e.getMessage(), e);
+            throw new RuntimeException("비용 조회 실패: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * NCP 계정의 일별 사용량 조회
+     *
+     * @param accountId NCP 계정 ID
+     * @param startDay 시작 일 (YYYYMMDD 형식, 예: 20240101)
+     * @param endDay 종료 일 (YYYYMMDD 형식, 예: 20240131)
+     * @return 일별 사용량 목록
+     */
+    public List<NcpDailyUsage> getDailyUsage(Long accountId, String startDay, String endDay) {
+        NcpAccount account = validateAndGetAccount(accountId);
+        log.info("Fetching NCP daily usage for account {} from {} to {}", accountId, startDay, endDay);
+
+        try {
+            Map<String, String> params = buildDailyParams(startDay, endDay);
+            JsonNode response = apiClient.callBillingApi(
+                    "/cost/getContractUsageListByDaily",
+                    params,
+                    account.getAccessKey(),
+                    account.getSecretKeyEnc()
+            );
+
+            List<NcpDailyUsage> usageList = parseContractUsageListByDaily(response);
+            log.info("Found {} daily usage records for account {} from {} to {}", usageList.size(), accountId, startDay, endDay);
+            return usageList;
+
+        } catch (Exception e) {
+            log.error("Failed to fetch daily usage for account {} from {} to {}: {}", accountId, startDay, endDay, e.getMessage(), e);
+            throw new RuntimeException("일별 사용량 조회 실패: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * 계정 검증 및 조회
+     */
+    private NcpAccount validateAndGetAccount(Long accountId) {
+        NcpAccount account = accountRepository.findById(accountId)
+                .orElseThrow(() -> new ResponseStatusException(NOT_FOUND, ERROR_MSG_ACCOUNT_NOT_FOUND));
+
+        if (!Boolean.TRUE.equals(account.getActive())) {
+            throw new IllegalStateException(ERROR_MSG_INACTIVE_ACCOUNT);
+        }
+
+        return account;
+    }
+
+    /**
+     * 월별 조회 파라미터 생성
+     */
+    private Map<String, String> buildMonthlyParams(String startMonth, String endMonth) {
+        Map<String, String> params = new HashMap<>();
+        params.put("startMonth", startMonth);
+        params.put("endMonth", endMonth);
+        params.put("responseFormatType", RESPONSE_FORMAT_JSON);
+        return params;
+    }
+
+    /**
+     * 일별 조회 파라미터 생성
+     */
+    private Map<String, String> buildDailyParams(String startDay, String endDay) {
+        Map<String, String> params = new HashMap<>();
+        params.put("useStartDay", startDay);
+        params.put("useEndDay", endDay);
+        params.put("responseFormatType", RESPONSE_FORMAT_JSON);
+        return params;
+    }
+
+    /**
+     * JSON 응답을 파싱하여 일별 사용량 목록 반환
+     */
+    private List<NcpDailyUsage> parseContractUsageListByDaily(JsonNode response) {
+        List<NcpDailyUsage> usageList = new ArrayList<>();
+
+        JsonNode responseNode = response.path("getContractUsageListByDailyResponse");
+
+        if (responseNode.has("contractUsageListByDaily")) {
+            JsonNode dailyList = responseNode.get("contractUsageListByDaily");
+            if (dailyList.isArray()) {
+                for (JsonNode usage : dailyList) {
+                    usageList.add(parseDailyUsage(usage));
+                }
+            }
+        }
+
+        return usageList;
+    }
+
+    /**
+     * 단일 일별 사용량 파싱
+     */
+    private NcpDailyUsage parseDailyUsage(JsonNode usage) {
+        String useDate = formatDateToYYYYMMDD(usage.path("useDate").path("useStartDate").asText(""));
+
+        return NcpDailyUsage.builder()
+                .useDate(useDate)
+                .contractNo(getTextOrNull(usage, "contract", "contractNo"))
+                .instanceName(getTextOrNull(usage, "contract", "instanceName"))
+                .contractType(getCodeNameOrNull(usage, "contract", "contractType"))
+                .productItemKind(getCodeNameOrNull(usage, "contractProduct", "productItemKind"))
+                .usageQuantity(usage.path("usage").path("usageQuantity").asDouble(0.0))
+                .unit(getCodeNameOrNull(usage, "usage", "unit"))
+                .regionCode(getTextOrNull(usage, "contract", "regionCode"))
+                .build();
+    }
+
+    /**
+     * ISO 날짜 문자열을 YYYYMMDD 형식으로 변환
+     */
+    private String formatDateToYYYYMMDD(String isoDate) {
+        if (isoDate == null || isoDate.length() < 10) {
+            return "";
+        }
+        return isoDate.substring(0, 10).replace("-", "");
+    }
+
+    /**
+     * JsonNode에서 중첩된 텍스트 값 추출 (null-safe)
+     */
+    private String getTextOrNull(JsonNode node, String... paths) {
+        JsonNode current = node;
+        for (String path : paths) {
+            current = current.path(path);
+            if (current.isMissingNode()) {
+                return null;
+            }
+        }
+        return current.asText(null);
+    }
+
+    /**
+     * JsonNode에서 codeName 추출 (null-safe)
+     */
+    private String getCodeNameOrNull(JsonNode node, String... paths) {
+        JsonNode current = node;
+        for (String path : paths) {
+            current = current.path(path);
+            if (current.isMissingNode()) {
+                return null;
+            }
+        }
+        return current.path("codeName").asText(null);
+    }
+
+    /**
+     * JSON 응답을 파싱하여 월별 비용 목록 반환
+     */
+    private List<NcpMonthlyCost> parseContractDemandCostList(JsonNode response) {
+        List<NcpMonthlyCost> costs = new ArrayList<>();
+
+        JsonNode responseNode = response.path("getContractDemandCostListResponse");
+
+        if (responseNode.has("contractDemandCostList")) {
+            JsonNode costList = responseNode.get("contractDemandCostList");
+            if (costList.isArray()) {
+                for (JsonNode cost : costList) {
+                    costs.add(parseMonthlyCost(cost));
+                }
+            }
+        }
+
+        return costs;
+    }
+
+    /**
+     * 단일 월별 비용 파싱
+     */
+    private NcpMonthlyCost parseMonthlyCost(JsonNode cost) {
+        return NcpMonthlyCost.builder()
+                .demandMonth(cost.path("demandMonth").asText(null))
+                .demandType(getCodeNameOrNull(cost, "demandType"))
+                .demandTypeDetail(getCodeNameOrNull(cost, "demandTypeDetail"))
+                .contractNo(getTextOrNull(cost, "contract", "contractNo"))
+                .instanceName(getTextOrNull(cost, "contract", "instanceName"))
+                .demandAmount(cost.path("demandAmount").asDouble(0.0))
+                .useAmount(cost.path("useAmount").asDouble(0.0))
+                .promotionDiscountAmount(cost.path("promotionDiscountAmount").asDouble(0.0))
+                .etcDiscountAmount(cost.path("etcDiscountAmount").asDouble(0.0))
+                .currency(getCodeNameOrNull(cost, "payCurrency"))
+                .build();
+    }
+}

--- a/src/main/java/com/budgetops/backend/ncp/service/NcpCredentialValidator.java
+++ b/src/main/java/com/budgetops/backend/ncp/service/NcpCredentialValidator.java
@@ -1,0 +1,45 @@
+package com.budgetops.backend.ncp.service;
+
+import com.budgetops.backend.ncp.client.NcpApiClient;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NcpCredentialValidator {
+
+    private final NcpApiClient apiClient;
+
+    /**
+     * NCP 자격증명 유효성 검증
+     * getServerInstanceList API를 호출하여 자격증명이 유효한지 확인합니다.
+     *
+     * @param accessKey NCP Access Key
+     * @param secretKey NCP Secret Key
+     * @param regionCode 리전 코드 (optional, null 가능)
+     * @return 유효하면 true, 그렇지 않으면 false
+     */
+    public boolean isValid(String accessKey, String secretKey, String regionCode) {
+        try {
+            Map<String, String> params = new HashMap<>();
+            if (regionCode != null && !regionCode.isBlank()) {
+                params.put("regionCode", regionCode);
+            }
+            params.put("responseFormatType", "json");
+
+            // getServerInstanceList API 호출
+            apiClient.callServerApi("/vserver/v2/getServerInstanceList", params, accessKey, secretKey);
+
+            log.info("NCP credential validation successful for accessKey: {}", accessKey);
+            return true;
+        } catch (Exception ex) {
+            log.warn("NCP credential validation failed for accessKey: {}, error: {}", accessKey, ex.getMessage());
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/budgetops/backend/ncp/service/NcpServerService.java
+++ b/src/main/java/com/budgetops/backend/ncp/service/NcpServerService.java
@@ -1,0 +1,203 @@
+package com.budgetops.backend.ncp.service;
+
+import com.budgetops.backend.ncp.client.NcpApiClient;
+import com.budgetops.backend.ncp.dto.NcpServerInstanceResponse;
+import com.budgetops.backend.ncp.entity.NcpAccount;
+import com.budgetops.backend.ncp.repository.NcpAccountRepository;
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NcpServerService {
+
+    private final NcpAccountRepository accountRepository;
+    private final NcpApiClient apiClient;
+
+    /**
+     * 특정 NCP 계정의 서버 인스턴스 목록 조회
+     *
+     * @param accountId NCP 계정 ID
+     * @param regionCode 조회할 리전 (null이면 계정의 기본 리전)
+     * @return 서버 인스턴스 목록
+     */
+    public List<NcpServerInstanceResponse> listInstances(Long accountId, String regionCode) {
+        NcpAccount account = accountRepository.findById(accountId)
+                .orElseThrow(() -> new ResponseStatusException(NOT_FOUND, "NCP 계정을 찾을 수 없습니다."));
+
+        if (!Boolean.TRUE.equals(account.getActive())) {
+            throw new IllegalStateException("비활성화된 계정입니다.");
+        }
+
+        String targetRegion = regionCode != null ? regionCode : account.getRegionCode();
+
+        log.info("Fetching NCP server instances for account {} in region {}", accountId, targetRegion);
+
+        try {
+            Map<String, String> params = new HashMap<>();
+            if (targetRegion != null && !targetRegion.isBlank()) {
+                params.put("regionCode", targetRegion);
+            }
+            params.put("responseFormatType", "json");
+
+            JsonNode response = apiClient.callServerApi(
+                    "/vserver/v2/getServerInstanceList",
+                    params,
+                    account.getAccessKey(),
+                    account.getSecretKeyEnc()
+            );
+
+            log.info("NCP API Response: {}", response.toString());
+            List<NcpServerInstanceResponse> instances = parseServerInstanceList(response);
+            log.info("Found {} server instances in region {} for account {}", instances.size(), targetRegion, accountId);
+            return instances;
+
+        } catch (Exception e) {
+            log.error("Failed to fetch server instances for account {} in region {}: {}", accountId, targetRegion, e.getMessage(), e);
+            throw new RuntimeException("서버 인스턴스 조회 실패: " + e.getMessage());
+        }
+    }
+
+    /**
+     * 서버 인스턴스 시작
+     */
+    public List<NcpServerInstanceResponse> startInstances(Long accountId, List<String> serverInstanceNos, String regionCode) {
+        NcpAccount account = getActiveAccount(accountId);
+
+        log.info("Starting NCP server instances {} for account {}", serverInstanceNos, accountId);
+
+        try {
+            Map<String, String> params = buildServerActionParams(serverInstanceNos, regionCode, account);
+
+            JsonNode response = apiClient.callServerApi(
+                    "/vserver/v2/startServerInstances",
+                    params,
+                    account.getAccessKey(),
+                    account.getSecretKeyEnc()
+            );
+
+            return parseServerInstanceList(response);
+
+        } catch (Exception e) {
+            log.error("Failed to start server instances for account {}: {}", accountId, e.getMessage(), e);
+            throw new RuntimeException("서버 시작 실패: " + e.getMessage());
+        }
+    }
+
+    /**
+     * 서버 인스턴스 정지
+     */
+    public List<NcpServerInstanceResponse> stopInstances(Long accountId, List<String> serverInstanceNos, String regionCode) {
+        NcpAccount account = getActiveAccount(accountId);
+
+        log.info("Stopping NCP server instances {} for account {}", serverInstanceNos, accountId);
+
+        try {
+            Map<String, String> params = buildServerActionParams(serverInstanceNos, regionCode, account);
+
+            JsonNode response = apiClient.callServerApi(
+                    "/vserver/v2/stopServerInstances",
+                    params,
+                    account.getAccessKey(),
+                    account.getSecretKeyEnc()
+            );
+
+            return parseServerInstanceList(response);
+
+        } catch (Exception e) {
+            log.error("Failed to stop server instances for account {}: {}", accountId, e.getMessage(), e);
+            throw new RuntimeException("서버 정지 실패: " + e.getMessage());
+        }
+    }
+
+    /**
+     * 활성화된 계정 조회
+     */
+    private NcpAccount getActiveAccount(Long accountId) {
+        NcpAccount account = accountRepository.findById(accountId)
+                .orElseThrow(() -> new ResponseStatusException(NOT_FOUND, "NCP 계정을 찾을 수 없습니다."));
+
+        if (!Boolean.TRUE.equals(account.getActive())) {
+            throw new IllegalStateException("비활성화된 계정입니다.");
+        }
+
+        return account;
+    }
+
+    /**
+     * 서버 액션용 파라미터 빌드
+     */
+    private Map<String, String> buildServerActionParams(List<String> serverInstanceNos, String regionCode, NcpAccount account) {
+        Map<String, String> params = new HashMap<>();
+
+        String targetRegion = regionCode != null ? regionCode : account.getRegionCode();
+        if (targetRegion != null && !targetRegion.isBlank()) {
+            params.put("regionCode", targetRegion);
+        }
+
+        // serverInstanceNoList.1=xxx&serverInstanceNoList.2=yyy 형식
+        for (int i = 0; i < serverInstanceNos.size(); i++) {
+            params.put("serverInstanceNoList." + (i + 1), serverInstanceNos.get(i));
+        }
+
+        params.put("responseFormatType", "json");
+        return params;
+    }
+
+    /**
+     * JSON 응답을 파싱하여 서버 인스턴스 목록 반환
+     */
+    private List<NcpServerInstanceResponse> parseServerInstanceList(JsonNode response) {
+        List<NcpServerInstanceResponse> instances = new ArrayList<>();
+
+        // 응답 형식: getServerInstanceListResponse, startServerInstancesResponse, stopServerInstancesResponse 등
+        JsonNode responseNode = response.fields().hasNext() ? response.fields().next().getValue() : response;
+
+        if (responseNode.has("serverInstanceList")) {
+            JsonNode serverList = responseNode.get("serverInstanceList");
+            if (serverList.isArray()) {
+                for (JsonNode server : serverList) {
+                    instances.add(parseServerInstance(server));
+                }
+            }
+        }
+
+        return instances;
+    }
+
+    /**
+     * 단일 서버 인스턴스 파싱
+     */
+    private NcpServerInstanceResponse parseServerInstance(JsonNode server) {
+        return NcpServerInstanceResponse.builder()
+                .serverInstanceNo(server.path("serverInstanceNo").asText(null))
+                .serverName(server.path("serverName").asText(null))
+                .serverDescription(server.path("serverDescription").asText(null))
+                .cpuCount(server.path("cpuCount").asInt(0))
+                .memorySize(server.path("memorySize").asLong(0L))
+                .platformType(server.path("platformType").path("codeName").asText(null))
+                .publicIp(server.path("publicIp").asText(null))
+                .serverInstanceStatus(server.path("serverInstanceStatus").path("code").asText(null))
+                .serverInstanceStatusName(server.path("serverInstanceStatusName").asText(null))
+                .createDate(server.path("createDate").asText(null))
+                .uptime(server.path("uptime").asText(null))
+                .serverImageProductCode(server.path("serverImageProductCode").asText(null))
+                .serverProductCode(server.path("serverProductCode").asText(null))
+                .zoneCode(server.path("zoneCode").asText(null))
+                .regionCode(server.path("regionCode").asText(null))
+                .vpcNo(server.path("vpcNo").asText(null))
+                .subnetNo(server.path("subnetNo").asText(null))
+                .build();
+    }
+}

--- a/src/main/java/com/budgetops/backend/ncp/service/NcpSignatureGenerator.java
+++ b/src/main/java/com/budgetops/backend/ncp/service/NcpSignatureGenerator.java
@@ -1,0 +1,54 @@
+package com.budgetops.backend.ncp.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+@Slf4j
+@Component
+public class NcpSignatureGenerator {
+
+    /**
+     * NCP API 요청을 위한 시그니처를 생성합니다.
+     *
+     * @param method HTTP 메서드 (GET, POST 등)
+     * @param url API 경로 (쿼리 파라미터 포함, 예: /vserver/v2/getServerInstanceList?regionCode=KR)
+     * @param timestamp Unix timestamp (밀리초)
+     * @param accessKey NCP Access Key
+     * @param secretKey NCP Secret Key
+     * @return Base64로 인코딩된 시그니처
+     */
+    public String generateSignature(String method, String url, String timestamp, String accessKey, String secretKey) {
+        try {
+            String space = " ";
+            String newLine = "\n";
+
+            // 시그니처 메시지 생성
+            String message = new StringBuilder()
+                    .append(method)
+                    .append(space)
+                    .append(url)
+                    .append(newLine)
+                    .append(timestamp)
+                    .append(newLine)
+                    .append(accessKey)
+                    .toString();
+
+            // HmacSHA256으로 서명
+            SecretKeySpec signingKey = new SecretKeySpec(secretKey.getBytes(StandardCharsets.UTF_8), "HmacSHA256");
+            Mac mac = Mac.getInstance("HmacSHA256");
+            mac.init(signingKey);
+
+            byte[] rawHmac = mac.doFinal(message.getBytes(StandardCharsets.UTF_8));
+            return Base64.getEncoder().encodeToString(rawHmac);
+
+        } catch (Exception e) {
+            log.error("Failed to generate NCP signature", e);
+            throw new IllegalStateException("NCP 시그니처 생성에 실패했습니다: " + e.getMessage(), e);
+        }
+    }
+}


### PR DESCRIPTION
NCP 계정 관리 및 비용 조회 기능을 백엔드에 추가했습니다.

주요 변경사항:
- NCP API 클라이언트 구현
  - HMAC-SHA256 서명 기반 인증
  - Billing API 및 Server API 연동
- NCP 계정 관리
  - 계정 CRUD API
  - 계정 정보 암호화 저장
  - 자격증명 검증
- NCP 비용 조회
  - 월별 비용 조회 API
  - 일별 사용량 조회 API
- NCP 서버 인스턴스 관리
  - 서버 목록 조회 API
  - 서버 시작/정지 API

구현 내용:
- Client: NcpApiClient, NcpSignatureGenerator
- Controller: NcpAccountController, NcpServerController
- Service: NcpAccountService, NcpCostService, NcpServerService, NcpCredentialValidator
- Entity: NcpAccount
- Repository: NcpAccountRepository
- DTO: 7개 (Account, Cost, Usage, Server 관련)

Closes #17