### PR TITLE
Feature/14 AWS EC2 메트릭 알림 규칙 엔진 구현

### DIFF
--- a/src/main/java/com/budgetops/backend/BudgetopsBackendApplication.java
+++ b/src/main/java/com/budgetops/backend/BudgetopsBackendApplication.java
@@ -3,9 +3,11 @@ package com.budgetops.backend;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication(scanBasePackages = {"com.budgetops.backend"})
 @EnableJpaAuditing
+@EnableScheduling
 public class BudgetopsBackendApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/budgetops/backend/aws/controller/AwsEc2AlertController.java
+++ b/src/main/java/com/budgetops/backend/aws/controller/AwsEc2AlertController.java
@@ -1,0 +1,45 @@
+package com.budgetops.backend.aws.controller;
+
+import com.budgetops.backend.aws.dto.AwsEc2Alert;
+import com.budgetops.backend.aws.service.AwsEc2AlertService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+/**
+ * AWS EC2 알림 API 컨트롤러
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/aws/alerts")
+@RequiredArgsConstructor
+public class AwsEc2AlertController {
+    
+    private final AwsEc2AlertService alertService;
+    
+    /**
+     * 모든 계정의 알림 확인 및 발송
+     * POST /api/aws/alerts/check
+     */
+    @PostMapping("/check")
+    public ResponseEntity<List<AwsEc2Alert>> checkAllAccounts() {
+        log.info("Manual alert check triggered");
+        List<AwsEc2Alert> alerts = alertService.checkAllAccounts();
+        return ResponseEntity.ok(alerts);
+    }
+    
+    /**
+     * 특정 계정의 알림 확인 및 발송
+     * POST /api/aws/alerts/check/{accountId}
+     */
+    @PostMapping("/check/{accountId}")
+    public ResponseEntity<List<AwsEc2Alert>> checkAccount(@PathVariable Long accountId) {
+        log.info("Manual alert check triggered for account {}", accountId);
+        List<AwsEc2Alert> alerts = alertService.checkAccount(accountId);
+        return ResponseEntity.ok(alerts);
+    }
+}
+

--- a/src/main/java/com/budgetops/backend/aws/dto/AlertCondition.java
+++ b/src/main/java/com/budgetops/backend/aws/dto/AlertCondition.java
@@ -1,0 +1,97 @@
+package com.budgetops.backend.aws.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 알림 조건 정보
+ * yaml 파일의 conditions를 파싱한 결과
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AlertCondition {
+    /**
+     * 메트릭 이름 (cpu_utilization, memory_utilization, network_in 등)
+     */
+    private String metric;
+    
+    /**
+     * 임계값 (숫자 또는 문자열)
+     */
+    private Object threshold;
+    
+    /**
+     * 기간 (예: "7d", "14d", "365d")
+     */
+    private String period;
+    
+    /**
+     * 값 (임계값이 아닌 경우, 예: instance_type의 value)
+     */
+    private String value;
+    
+    /**
+     * 비교 연산자 (<, >, <=, >=, ==)
+     * 기본값: < (임계값 미만)
+     */
+    @Builder.Default
+    private String operator = "<";
+    
+    /**
+     * 기간을 일 단위로 변환
+     */
+    public int getPeriodInDays() {
+        if (period == null || period.isEmpty()) {
+            return 7; // 기본값 7일
+        }
+        
+        // "7d" -> 7, "14d" -> 14, "365d" -> 365
+        String periodStr = period.toLowerCase().trim();
+        if (periodStr.endsWith("d")) {
+            try {
+                return Integer.parseInt(periodStr.substring(0, periodStr.length() - 1));
+            } catch (NumberFormatException e) {
+                return 7;
+            }
+        }
+        
+        return 7;
+    }
+    
+    /**
+     * 임계값을 숫자로 변환
+     */
+    public Double getThresholdAsDouble() {
+        if (threshold == null) {
+            return null;
+        }
+        
+        if (threshold instanceof Number) {
+            return ((Number) threshold).doubleValue();
+        }
+        
+        if (threshold instanceof String) {
+            try {
+                String thresholdStr = ((String) threshold).trim();
+                // "1MB" 같은 경우 처리
+                if (thresholdStr.endsWith("MB")) {
+                    return Double.parseDouble(thresholdStr.substring(0, thresholdStr.length() - 2)) * 1024 * 1024;
+                } else if (thresholdStr.endsWith("GB")) {
+                    return Double.parseDouble(thresholdStr.substring(0, thresholdStr.length() - 2)) * 1024 * 1024 * 1024;
+                } else if (thresholdStr.endsWith("KB")) {
+                    return Double.parseDouble(thresholdStr.substring(0, thresholdStr.length() - 2)) * 1024;
+                }
+                return Double.parseDouble(thresholdStr);
+            } catch (NumberFormatException e) {
+                return null;
+            }
+        }
+        
+        return null;
+    }
+}
+

--- a/src/main/java/com/budgetops/backend/aws/dto/AlertRule.java
+++ b/src/main/java/com/budgetops/backend/aws/dto/AlertRule.java
@@ -1,0 +1,49 @@
+package com.budgetops.backend.aws.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * 알림 규칙 정보
+ * yaml 파일의 rule 하나를 파싱한 결과
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AlertRule {
+    /**
+     * 규칙 ID
+     */
+    private String id;
+    
+    /**
+     * 규칙 제목
+     */
+    private String title;
+    
+    /**
+     * 규칙 설명
+     */
+    private String description;
+    
+    /**
+     * 알림 조건 목록
+     */
+    private List<AlertCondition> conditions;
+    
+    /**
+     * 권장사항
+     */
+    private String recommendation;
+    
+    /**
+     * 예상 절감액
+     */
+    private String costSaving;
+}
+

--- a/src/main/java/com/budgetops/backend/aws/dto/AwsEc2Alert.java
+++ b/src/main/java/com/budgetops/backend/aws/dto/AwsEc2Alert.java
@@ -1,0 +1,110 @@
+package com.budgetops.backend.aws.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * AWS EC2 알림 정보
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AwsEc2Alert {
+    /**
+     * 알림 ID
+     */
+    private Long id;
+    
+    /**
+     * AWS 계정 ID
+     */
+    private Long accountId;
+    
+    /**
+     * AWS 계정 이름
+     */
+    private String accountName;
+    
+    /**
+     * EC2 인스턴스 ID
+     */
+    private String instanceId;
+    
+    /**
+     * 인스턴스 이름
+     */
+    private String instanceName;
+    
+    /**
+     * 규칙 ID
+     */
+    private String ruleId;
+    
+    /**
+     * 규칙 제목
+     */
+    private String ruleTitle;
+    
+    /**
+     * 위반한 조건 메트릭
+     */
+    private String violatedMetric;
+    
+    /**
+     * 현재 값
+     */
+    private Double currentValue;
+    
+    /**
+     * 임계값
+     */
+    private Double threshold;
+    
+    /**
+     * 알림 메시지
+     */
+    private String message;
+    
+    /**
+     * 알림 심각도 (INFO, WARNING, CRITICAL)
+     */
+    private AlertSeverity severity;
+    
+    /**
+     * 알림 상태 (PENDING, SENT, ACKNOWLEDGED)
+     */
+    private AlertStatus status;
+    
+    /**
+     * 알림 생성 시간
+     */
+    private LocalDateTime createdAt;
+    
+    /**
+     * 알림 발송 시간
+     */
+    private LocalDateTime sentAt;
+    
+    /**
+     * 알림 확인 시간
+     */
+    private LocalDateTime acknowledgedAt;
+    
+    public enum AlertSeverity {
+        INFO,
+        WARNING,
+        CRITICAL
+    }
+    
+    public enum AlertStatus {
+        PENDING,      // 대기 중
+        SENT,         // 발송됨
+        ACKNOWLEDGED  // 확인됨
+    }
+}
+

--- a/src/main/java/com/budgetops/backend/aws/scheduler/AwsEc2AlertScheduler.java
+++ b/src/main/java/com/budgetops/backend/aws/scheduler/AwsEc2AlertScheduler.java
@@ -1,0 +1,55 @@
+package com.budgetops.backend.aws.scheduler;
+
+import com.budgetops.backend.aws.dto.AwsEc2Alert;
+import com.budgetops.backend.aws.service.AwsEc2AlertService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * AWS EC2 알림 스케줄러
+ * 주기적으로 임계치를 확인하고 알림을 발송합니다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AwsEc2AlertScheduler {
+    
+    private final AwsEc2AlertService alertService;
+    
+    /**
+     * 매일 오전 9시에 실행
+     * 모든 활성 AWS 계정의 EC2 인스턴스 임계치 확인
+     */
+    @Scheduled(cron = "0 0 9 * * *") // 매일 오전 9시
+    public void checkThresholdsDaily() {
+        log.info("Starting scheduled AWS EC2 threshold check");
+        
+        try {
+            List<AwsEc2Alert> alerts = alertService.checkAllAccounts();
+            log.info("Scheduled check completed: {} alerts generated", alerts.size());
+        } catch (Exception e) {
+            log.error("Failed to execute scheduled threshold check", e);
+        }
+    }
+    
+    /**
+     * 매 6시간마다 실행
+     * 더 빈번한 모니터링이 필요한 경우
+     */
+    @Scheduled(cron = "0 0 */6 * * *") // 6시간마다
+    public void checkThresholdsPeriodically() {
+        log.info("Starting periodic AWS EC2 threshold check");
+        
+        try {
+            List<AwsEc2Alert> alerts = alertService.checkAllAccounts();
+            log.info("Periodic check completed: {} alerts generated", alerts.size());
+        } catch (Exception e) {
+            log.error("Failed to execute periodic threshold check", e);
+        }
+    }
+}
+

--- a/src/main/java/com/budgetops/backend/aws/service/AwsEc2AlertService.java
+++ b/src/main/java/com/budgetops/backend/aws/service/AwsEc2AlertService.java
@@ -1,0 +1,402 @@
+package com.budgetops.backend.aws.service;
+
+import com.budgetops.backend.aws.dto.*;
+import com.budgetops.backend.aws.entity.AwsAccount;
+import com.budgetops.backend.aws.repository.AwsAccountRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.cloudwatch.CloudWatchClient;
+import software.amazon.awssdk.services.cloudwatch.model.*;
+import software.amazon.awssdk.services.ec2.Ec2Client;
+import software.amazon.awssdk.services.ec2.model.*;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+/**
+ * AWS EC2 리소스 사용량 임계치 초과 시 알림 발송 서비스
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AwsEc2AlertService {
+    
+    private final AwsAccountRepository accountRepository;
+    private final AwsEc2Service ec2Service;
+    private final AwsEc2RuleLoader ruleLoader;
+    
+    /**
+     * 모든 활성 AWS 계정의 EC2 인스턴스에 대해 임계치 확인 및 알림 발송
+     */
+    public List<AwsEc2Alert> checkAllAccounts() {
+        List<AwsAccount> activeAccounts = accountRepository.findByActiveTrue();
+        log.info("Checking thresholds for {} active AWS account(s)", activeAccounts.size());
+        
+        List<AwsEc2Alert> allAlerts = new ArrayList<>();
+        
+        for (AwsAccount account : activeAccounts) {
+            try {
+                List<AwsEc2Alert> accountAlerts = checkAccount(account.getId());
+                allAlerts.addAll(accountAlerts);
+            } catch (Exception e) {
+                log.error("Failed to check account {}: {}", account.getId(), e.getMessage(), e);
+            }
+        }
+        
+        log.info("Total {} alerts generated", allAlerts.size());
+        return allAlerts;
+    }
+    
+    /**
+     * 특정 AWS 계정의 EC2 인스턴스에 대해 임계치 확인 및 알림 발송
+     */
+    public List<AwsEc2Alert> checkAccount(Long accountId) {
+        AwsAccount account = accountRepository.findById(accountId)
+                .orElseThrow(() -> new ResponseStatusException(NOT_FOUND, "AWS 계정을 찾을 수 없습니다."));
+        
+        if (!Boolean.TRUE.equals(account.getActive())) {
+            log.warn("Account {} is not active, skipping alert check", accountId);
+            return new ArrayList<>();
+        }
+        
+        log.info("Checking thresholds for account {} ({})", accountId, account.getName());
+        
+        // EC2 인스턴스 목록 조회
+        List<AwsEc2InstanceResponse> instances = ec2Service.listInstances(accountId, null);
+        
+        // 모든 규칙 로드
+        List<AlertRule> rules = ruleLoader.getAllRules();
+        
+        List<AwsEc2Alert> alerts = new ArrayList<>();
+        
+        for (AwsEc2InstanceResponse instance : instances) {
+            // 실행 중인 인스턴스만 체크
+            if (!"running".equalsIgnoreCase(instance.getState())) {
+                continue;
+            }
+            
+            for (AlertRule rule : rules) {
+                List<AwsEc2Alert> ruleAlerts = checkRule(account, instance, rule);
+                alerts.addAll(ruleAlerts);
+            }
+        }
+        
+        // 알림 발송
+        for (AwsEc2Alert alert : alerts) {
+            sendAlert(alert);
+        }
+        
+        log.info("Generated {} alerts for account {}", alerts.size(), accountId);
+        return alerts;
+    }
+    
+    /**
+     * 특정 인스턴스와 규칙에 대해 임계치 확인
+     */
+    private List<AwsEc2Alert> checkRule(AwsAccount account, AwsEc2InstanceResponse instance, AlertRule rule) {
+        List<AwsEc2Alert> alerts = new ArrayList<>();
+        
+        try {
+            // 모든 조건이 만족되는지 확인
+            boolean allConditionsMet = true;
+            String violatedMetric = null;
+            Double currentValue = null;
+            Double threshold = null;
+            
+            for (AlertCondition condition : rule.getConditions()) {
+                MetricCheckResult result = checkCondition(account, instance, condition);
+                
+                if (!result.isViolated()) {
+                    allConditionsMet = false;
+                    break;
+                }
+                
+                // 위반한 조건 정보 저장 (첫 번째 위반 조건)
+                if (violatedMetric == null) {
+                    violatedMetric = condition.getMetric();
+                    currentValue = result.getCurrentValue();
+                    threshold = result.getThreshold();
+                }
+            }
+            
+            // 모든 조건이 만족되면 알림 생성
+            if (allConditionsMet) {
+                AwsEc2Alert alert = createAlert(account, instance, rule, violatedMetric, currentValue, threshold);
+                alerts.add(alert);
+            }
+            
+        } catch (Exception e) {
+            log.error("Failed to check rule {} for instance {}: {}", 
+                    rule.getId(), instance.getInstanceId(), e.getMessage(), e);
+        }
+        
+        return alerts;
+    }
+    
+    /**
+     * 특정 조건에 대해 메트릭 확인
+     */
+    private MetricCheckResult checkCondition(AwsAccount account, AwsEc2InstanceResponse instance, AlertCondition condition) {
+        String metric = condition.getMetric();
+        String region = account.getDefaultRegion() != null ? account.getDefaultRegion() : "us-east-1";
+        int periodDays = condition.getPeriodInDays();
+        
+        try {
+            // period에 해당하는 시간만큼 메트릭 조회
+            Instant endTime = Instant.now();
+            Instant startTime = endTime.minus(periodDays, ChronoUnit.DAYS);
+            
+            try (CloudWatchClient cloudWatchClient = createCloudWatchClient(account, region)) {
+                // 메트릭별로 처리
+                double averageValue = 0.0;
+                boolean hasData = false;
+                
+                switch (metric) {
+                    case "cpu_utilization":
+                        averageValue = getAverageMetricValue(cloudWatchClient, instance.getInstanceId(), 
+                                "AWS/EC2", "CPUUtilization", "Percent", startTime, endTime);
+                        hasData = true;
+                        break;
+                        
+                    case "memory_utilization":
+                        // CloudWatch Agent가 설치된 경우에만 사용 가능
+                        averageValue = getAverageMetricValue(cloudWatchClient, instance.getInstanceId(), 
+                                "CWAgent", "mem_used_percent", "Percent", startTime, endTime);
+                        hasData = averageValue > 0; // 데이터가 없으면 0
+                        break;
+                        
+                    case "network_in":
+                        averageValue = getAverageMetricValue(cloudWatchClient, instance.getInstanceId(), 
+                                "AWS/EC2", "NetworkIn", "Bytes", startTime, endTime);
+                        hasData = true;
+                        // 바이트를 MB로 변환 (기간 내 평균)
+                        averageValue = averageValue / (1024.0 * 1024.0);
+                        break;
+                        
+                    case "network_out":
+                        averageValue = getAverageMetricValue(cloudWatchClient, instance.getInstanceId(), 
+                                "AWS/EC2", "NetworkOut", "Bytes", startTime, endTime);
+                        hasData = true;
+                        // 바이트를 MB로 변환 (기간 내 평균)
+                        averageValue = averageValue / (1024.0 * 1024.0);
+                        break;
+                        
+                    default:
+                        log.warn("Unknown metric: {}", metric);
+                        return MetricCheckResult.notViolated();
+                }
+                
+                if (!hasData) {
+                    return MetricCheckResult.notViolated();
+                }
+                
+                // 임계값과 비교
+                Double threshold = condition.getThresholdAsDouble();
+                if (threshold == null) {
+                    return MetricCheckResult.notViolated();
+                }
+                
+                // 기본 연산자는 < (미만), 즉 현재값이 임계값보다 작으면 위반
+                boolean violated = averageValue < threshold;
+                
+                if (violated) {
+                    return MetricCheckResult.violated(averageValue, threshold);
+                } else {
+                    return MetricCheckResult.notViolated();
+                }
+            }
+            
+        } catch (Exception e) {
+            log.error("Failed to check condition {} for instance {}: {}", 
+                    metric, instance.getInstanceId(), e.getMessage());
+            return MetricCheckResult.notViolated();
+        }
+    }
+    
+    /**
+     * CloudWatch에서 메트릭의 평균값 조회
+     */
+    private double getAverageMetricValue(CloudWatchClient cloudWatchClient, String instanceId, 
+                                        String namespace, String metricName, String unit,
+                                        Instant startTime, Instant endTime) {
+        try {
+            GetMetricStatisticsRequest request = GetMetricStatisticsRequest.builder()
+                    .namespace(namespace)
+                    .metricName(metricName)
+                    .dimensions(Dimension.builder()
+                            .name("InstanceId")
+                            .value(instanceId)
+                            .build())
+                    .startTime(startTime)
+                    .endTime(endTime)
+                    .period(3600) // 1시간 단위
+                    .statistics(Statistic.AVERAGE)
+                    .build();
+            
+            GetMetricStatisticsResponse response = cloudWatchClient.getMetricStatistics(request);
+            
+            if (response.datapoints().isEmpty()) {
+                return 0.0;
+            }
+            
+            // 모든 데이터포인트의 평균값 계산
+            double sum = response.datapoints().stream()
+                    .mapToDouble(Datapoint::average)
+                    .sum();
+            
+            return sum / response.datapoints().size();
+            
+        } catch (CloudWatchException e) {
+            log.warn("Failed to get metric {} for instance {}: {}", 
+                    metricName, instanceId, e.awsErrorDetails().errorMessage());
+            return 0.0;
+        }
+    }
+    
+    /**
+     * 알림 생성
+     */
+    private AwsEc2Alert createAlert(AwsAccount account, AwsEc2InstanceResponse instance, 
+                                   AlertRule rule, String violatedMetric, 
+                                   Double currentValue, Double threshold) {
+        
+        // 심각도 결정
+        AwsEc2Alert.AlertSeverity severity = determineSeverity(violatedMetric, currentValue, threshold);
+        
+        // 알림 메시지 생성
+        String message = String.format(
+                "[%s] 인스턴스 %s(%s)에서 규칙 '%s' 위반 감지.\n" +
+                "메트릭: %s, 현재값: %.2f, 임계값: %.2f\n" +
+                "%s",
+                account.getName(),
+                instance.getName(),
+                instance.getInstanceId(),
+                rule.getTitle(),
+                violatedMetric,
+                currentValue != null ? currentValue : 0.0,
+                threshold != null ? threshold : 0.0,
+                rule.getRecommendation()
+        );
+        
+        return AwsEc2Alert.builder()
+                .accountId(account.getId())
+                .accountName(account.getName())
+                .instanceId(instance.getInstanceId())
+                .instanceName(instance.getName())
+                .ruleId(rule.getId())
+                .ruleTitle(rule.getTitle())
+                .violatedMetric(violatedMetric)
+                .currentValue(currentValue)
+                .threshold(threshold)
+                .message(message)
+                .severity(severity)
+                .status(AwsEc2Alert.AlertStatus.PENDING)
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+    
+    /**
+     * 심각도 결정
+     */
+    private AwsEc2Alert.AlertSeverity determineSeverity(String metric, Double currentValue, Double threshold) {
+        if (currentValue == null || threshold == null) {
+            return AwsEc2Alert.AlertSeverity.WARNING;
+        }
+        
+        // 임계값 대비 현재값 비율
+        double ratio = threshold > 0 ? (currentValue / threshold) * 100 : 0;
+        
+        // 임계값보다 50% 이상 낮으면 CRITICAL (심각한 낭비)
+        if (ratio < 50) {
+            return AwsEc2Alert.AlertSeverity.CRITICAL;
+        } else if (ratio < 70) {
+            return AwsEc2Alert.AlertSeverity.WARNING;
+        } else {
+            return AwsEc2Alert.AlertSeverity.INFO;
+        }
+    }
+    
+    /**
+     * 알림 발송
+     */
+    private void sendAlert(AwsEc2Alert alert) {
+        try {
+            // 현재는 로그로만 발송 (나중에 이메일, 웹훅 등으로 확장 가능)
+            log.warn("🚨 AWS EC2 Alert: {}", alert.getMessage());
+            
+            // 알림 상태 업데이트
+            alert.setStatus(AwsEc2Alert.AlertStatus.SENT);
+            alert.setSentAt(LocalDateTime.now());
+            
+            // TODO: 실제 알림 발송 로직 (이메일, 슬랙, 웹훅 등)
+            // - 이메일 발송
+            // - Slack 웹훅
+            // - 데이터베이스 저장
+            
+        } catch (Exception e) {
+            log.error("Failed to send alert: {}", alert.getMessage(), e);
+        }
+    }
+    
+    /**
+     * CloudWatch 클라이언트 생성
+     */
+    private CloudWatchClient createCloudWatchClient(AwsAccount account, String region) {
+        AwsBasicCredentials credentials = AwsBasicCredentials.create(
+                account.getAccessKeyId(),
+                account.getSecretKeyEnc()
+        );
+        
+        return CloudWatchClient.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(credentials))
+                .build();
+    }
+    
+    /**
+     * 메트릭 확인 결과
+     */
+    private static class MetricCheckResult {
+        private final boolean violated;
+        private final Double currentValue;
+        private final Double threshold;
+        
+        private MetricCheckResult(boolean violated, Double currentValue, Double threshold) {
+            this.violated = violated;
+            this.currentValue = currentValue;
+            this.threshold = threshold;
+        }
+        
+        public static MetricCheckResult violated(double currentValue, double threshold) {
+            return new MetricCheckResult(true, currentValue, threshold);
+        }
+        
+        public static MetricCheckResult notViolated() {
+            return new MetricCheckResult(false, null, null);
+        }
+        
+        public boolean isViolated() {
+            return violated;
+        }
+        
+        public Double getCurrentValue() {
+            return currentValue;
+        }
+        
+        public Double getThreshold() {
+            return threshold;
+        }
+    }
+}
+

--- a/src/main/java/com/budgetops/backend/aws/service/AwsEc2RuleLoader.java
+++ b/src/main/java/com/budgetops/backend/aws/service/AwsEc2RuleLoader.java
@@ -1,0 +1,135 @@
+package com.budgetops.backend.aws.service;
+
+import com.budgetops.backend.aws.dto.AlertCondition;
+import com.budgetops.backend.aws.dto.AlertRule;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+import org.springframework.stereotype.Component;
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.InputStream;
+import java.util.*;
+
+/**
+ * AWS EC2 알림 규칙 로더
+ * csp_aws_ec2.yml 파일을 로드하여 알림 규칙 정보 제공
+ */
+@Slf4j
+@Component
+public class AwsEc2RuleLoader {
+    
+    private final List<AlertRule> alertRules = new ArrayList<>();
+    private final Yaml yaml = new Yaml();
+    
+    public AwsEc2RuleLoader() {
+        loadRules();
+    }
+    
+    private void loadRules() {
+        try {
+            PathMatchingResourcePatternResolver resolver = new PathMatchingResourcePatternResolver();
+            Resource resource = resolver.getResource("classpath:costs/csp_aws_ec2.yml");
+            
+            if (!resource.exists()) {
+                log.warn("AWS EC2 rule file not found: csp_aws_ec2.yml");
+                return;
+            }
+            
+            try (InputStream inputStream = resource.getInputStream()) {
+                Map<String, Object> data = yaml.load(inputStream);
+                
+                @SuppressWarnings("unchecked")
+                List<Map<String, Object>> rulesList = (List<Map<String, Object>>) data.get("rules");
+                
+                if (rulesList != null) {
+                    for (Map<String, Object> ruleMap : rulesList) {
+                        AlertRule rule = parseRule(ruleMap);
+                        if (rule != null) {
+                            alertRules.add(rule);
+                        }
+                    }
+                    
+                    log.info("Loaded {} alert rules for AWS EC2", alertRules.size());
+                }
+            }
+        } catch (Exception e) {
+            log.error("Failed to load AWS EC2 alert rules", e);
+        }
+    }
+    
+    private AlertRule parseRule(Map<String, Object> ruleMap) {
+        try {
+            String id = (String) ruleMap.get("id");
+            String title = (String) ruleMap.get("title");
+            String description = (String) ruleMap.get("description");
+            String recommendation = (String) ruleMap.get("recommendation");
+            String costSaving = (String) ruleMap.get("cost_saving");
+            
+            @SuppressWarnings("unchecked")
+            List<Map<String, Object>> conditionsList = (List<Map<String, Object>>) ruleMap.get("conditions");
+            
+            List<AlertCondition> conditions = new ArrayList<>();
+            if (conditionsList != null) {
+                for (Map<String, Object> conditionMap : conditionsList) {
+                    AlertCondition condition = parseCondition(conditionMap);
+                    if (condition != null) {
+                        conditions.add(condition);
+                    }
+                }
+            }
+            
+            return AlertRule.builder()
+                    .id(id)
+                    .title(title)
+                    .description(description)
+                    .conditions(conditions)
+                    .recommendation(recommendation)
+                    .costSaving(costSaving)
+                    .build();
+                    
+        } catch (Exception e) {
+            log.error("Failed to parse alert rule: {}", ruleMap, e);
+            return null;
+        }
+    }
+    
+    private AlertCondition parseCondition(Map<String, Object> conditionMap) {
+        try {
+            String metric = (String) conditionMap.get("metric");
+            Object threshold = conditionMap.get("threshold");
+            String period = (String) conditionMap.get("period");
+            String value = (String) conditionMap.get("value");
+            
+            return AlertCondition.builder()
+                    .metric(metric)
+                    .threshold(threshold)
+                    .period(period)
+                    .value(value)
+                    .operator("<") // 기본값은 미만
+                    .build();
+                    
+        } catch (Exception e) {
+            log.error("Failed to parse condition: {}", conditionMap, e);
+            return null;
+        }
+    }
+    
+    /**
+     * 모든 알림 규칙 조회
+     */
+    public List<AlertRule> getAllRules() {
+        return new ArrayList<>(alertRules);
+    }
+    
+    /**
+     * 특정 규칙 ID로 규칙 조회
+     */
+    public AlertRule getRuleById(String ruleId) {
+        return alertRules.stream()
+                .filter(rule -> rule.getId().equals(ruleId))
+                .findFirst()
+                .orElse(null);
+    }
+}
+


### PR DESCRIPTION
## Feature/14 AWS EC2 메트릭 알림 규칙 엔진 구현

### 개요
AWS EC2 리소스의 CloudWatch 메트릭을 기반으로, YAML 규칙에서 정의한 임계치를 평가해 알림을 생성하는 **메트릭 기반 자동 알림 엔진**을 구현함.

### 주요 내용
- YAML 규칙(csp_aws_ec2.yml) 파싱 및 규칙·조건 모델링
- CloudWatch CPU/Memory/Network 메트릭 조회 로직 구현
- 임계치 비교 후 알림 DTO 생성 및 로그 기반 알림 발송
- 전체 계정/특정 계정 대상 알림 검사 API 추가
- 매일 9시 스케줄러 실행 및 주기 실행 옵션 제공

### 구성 요소
1. DTO
   - AlertCondition: YAML conditions 파싱 결과  
   - AlertRule: 규칙 단위 파싱 결과  
   - AwsEc2Alert: 계정·인스턴스·메트릭·심각도 정보 포함 알림 DTO  

2. 서비스
   - AwsEc2RuleLoader: YAML 파일 로드 및 규칙 제공  
   - AwsEc2AlertService: 메트릭 조회 → 임계치 비교 → 알림 생성  

3. 컨트롤러
   - POST `/api/aws/alerts/check`
   - POST `/api/aws/alerts/check/{accountId}`

4. 스케줄러
   - 매일 09:00 자동 검사
   - 선택적 6시간 주기 검사 지원

### 지원 메트릭
- CPUUtilization (%)
- MemoryUtilization (%)
- NetworkIn (MB)
- NetworkOut (MB)

### 기대 효과
- AWS EC2 이상 징후 자동 탐지 기반 확보  
- 규칙 기반 확장 가능 구조로 향후 알림 채널(이메일·웹훅) 연동 용이  
