### PR TITLE
Feature/18 GCP Compute Engine 리소스 알림 시스템 구현

### DIFF
--- a/src/main/java/com/budgetops/backend/aws/controller/AwsEc2AlertController.java
+++ b/src/main/java/com/budgetops/backend/aws/controller/AwsEc2AlertController.java
@@ -1,7 +1,7 @@
 package com.budgetops.backend.aws.controller;
 
 import com.budgetops.backend.aws.dto.AwsEc2Alert;
-import com.budgetops.backend.aws.service.AwsEc2AlertService;
+import com.budgetops.backend.aws.service.AwsAlertService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -10,7 +10,8 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 /**
- * AWS EC2 알림 API 컨트롤러
+ * AWS 통합 알림 API 컨트롤러
+ * EC2, RDS, S3 등 모든 AWS 서비스의 알림 제공
  */
 @Slf4j
 @RestController
@@ -18,27 +19,27 @@ import java.util.List;
 @RequiredArgsConstructor
 public class AwsEc2AlertController {
     
-    private final AwsEc2AlertService alertService;
+    private final AwsAlertService alertService;
     
     /**
-     * 모든 계정의 알림 확인 및 발송
+     * 모든 계정의 모든 AWS 서비스 알림 확인 및 발송
      * POST /api/aws/alerts/check
      */
     @PostMapping("/check")
     public ResponseEntity<List<AwsEc2Alert>> checkAllAccounts() {
-        log.info("Manual alert check triggered");
-        List<AwsEc2Alert> alerts = alertService.checkAllAccounts();
+        log.info("Manual alert check triggered for all AWS services");
+        List<AwsEc2Alert> alerts = alertService.checkAllServices();
         return ResponseEntity.ok(alerts);
     }
     
     /**
-     * 특정 계정의 알림 확인 및 발송
+     * 특정 계정의 모든 AWS 서비스 알림 확인 및 발송
      * POST /api/aws/alerts/check/{accountId}
      */
     @PostMapping("/check/{accountId}")
     public ResponseEntity<List<AwsEc2Alert>> checkAccount(@PathVariable Long accountId) {
-        log.info("Manual alert check triggered for account {}", accountId);
-        List<AwsEc2Alert> alerts = alertService.checkAccount(accountId);
+        log.info("Manual alert check triggered for all AWS services for account {}", accountId);
+        List<AwsEc2Alert> alerts = alertService.checkAllServicesForAccount(accountId);
         return ResponseEntity.ok(alerts);
     }
 }

--- a/src/main/java/com/budgetops/backend/aws/service/AwsAlertService.java
+++ b/src/main/java/com/budgetops/backend/aws/service/AwsAlertService.java
@@ -1,0 +1,69 @@
+package com.budgetops.backend.aws.service;
+
+import com.budgetops.backend.aws.dto.AwsEc2Alert;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * AWS 통합 알림 서비스
+ * EC2, RDS, S3 등 모든 AWS 서비스의 알림을 통합 관리
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AwsAlertService {
+    
+    private final AwsEc2AlertService ec2AlertService;
+    // TODO: RDS, S3 등 다른 서비스 알림 서비스 추가 예정
+    
+    /**
+     * 모든 AWS 서비스의 알림을 통합하여 반환
+     */
+    public List<AwsEc2Alert> checkAllServices() {
+        log.info("Checking alerts for all AWS services");
+        List<AwsEc2Alert> allAlerts = new ArrayList<>();
+        
+        try {
+            // EC2 알림
+            List<AwsEc2Alert> ec2Alerts = ec2AlertService.checkAllAccounts();
+            allAlerts.addAll(ec2Alerts);
+            log.info("EC2 alerts: {}", ec2Alerts.size());
+        } catch (Exception e) {
+            log.error("Failed to check EC2 alerts", e);
+        }
+        
+        // TODO: RDS 알림 추가
+        // TODO: S3 알림 추가
+        // TODO: Lambda 알림 추가
+        // TODO: DynamoDB 알림 추가
+        
+        log.info("Total AWS alerts: {}", allAlerts.size());
+        return allAlerts;
+    }
+    
+    /**
+     * 특정 계정의 모든 서비스 알림 체크
+     */
+    public List<AwsEc2Alert> checkAllServicesForAccount(Long accountId) {
+        log.info("Checking alerts for all AWS services for account {}", accountId);
+        List<AwsEc2Alert> allAlerts = new ArrayList<>();
+        
+        try {
+            // EC2 알림
+            List<AwsEc2Alert> ec2Alerts = ec2AlertService.checkAccount(accountId);
+            allAlerts.addAll(ec2Alerts);
+        } catch (Exception e) {
+            log.error("Failed to check EC2 alerts for account {}", accountId, e);
+        }
+        
+        // TODO: 다른 서비스 알림 추가
+        
+        log.info("Total AWS alerts for account {}: {}", accountId, allAlerts.size());
+        return allAlerts;
+    }
+}
+

--- a/src/main/java/com/budgetops/backend/aws/service/AwsRdsRuleLoader.java
+++ b/src/main/java/com/budgetops/backend/aws/service/AwsRdsRuleLoader.java
@@ -1,0 +1,129 @@
+package com.budgetops.backend.aws.service;
+
+import com.budgetops.backend.aws.dto.AlertCondition;
+import com.budgetops.backend.aws.dto.AlertRule;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+import org.springframework.stereotype.Component;
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.InputStream;
+import java.util.*;
+
+/**
+ * AWS RDS 알림 규칙 로더
+ * csp_aws_rds.yml 파일을 로드하여 알림 규칙 정보 제공
+ */
+@Slf4j
+@Component
+public class AwsRdsRuleLoader {
+    
+    private final List<AlertRule> alertRules = new ArrayList<>();
+    private final Yaml yaml = new Yaml();
+    
+    public AwsRdsRuleLoader() {
+        loadRules();
+    }
+    
+    private void loadRules() {
+        try {
+            PathMatchingResourcePatternResolver resolver = new PathMatchingResourcePatternResolver();
+            Resource resource = resolver.getResource("classpath:costs/csp_aws_rds.yml");
+            
+            if (!resource.exists()) {
+                log.warn("AWS RDS rule file not found: csp_aws_rds.yml");
+                return;
+            }
+            
+            try (InputStream inputStream = resource.getInputStream()) {
+                Map<String, Object> data = yaml.load(inputStream);
+                
+                @SuppressWarnings("unchecked")
+                List<Map<String, Object>> rulesList = (List<Map<String, Object>>) data.get("rules");
+                
+                if (rulesList != null) {
+                    for (Map<String, Object> ruleMap : rulesList) {
+                        AlertRule rule = parseRule(ruleMap);
+                        if (rule != null) {
+                            alertRules.add(rule);
+                        }
+                    }
+                    
+                    log.info("Loaded {} alert rules for AWS RDS", alertRules.size());
+                }
+            }
+        } catch (Exception e) {
+            log.error("Failed to load AWS RDS alert rules", e);
+        }
+    }
+    
+    private AlertRule parseRule(Map<String, Object> ruleMap) {
+        try {
+            String id = (String) ruleMap.get("id");
+            String title = (String) ruleMap.get("title");
+            String description = (String) ruleMap.get("description");
+            String recommendation = (String) ruleMap.get("recommendation");
+            String costSaving = (String) ruleMap.get("cost_saving");
+            
+            @SuppressWarnings("unchecked")
+            List<Map<String, Object>> conditionsList = (List<Map<String, Object>>) ruleMap.get("conditions");
+            
+            List<AlertCondition> conditions = new ArrayList<>();
+            if (conditionsList != null) {
+                for (Map<String, Object> conditionMap : conditionsList) {
+                    AlertCondition condition = parseCondition(conditionMap);
+                    if (condition != null) {
+                        conditions.add(condition);
+                    }
+                }
+            }
+            
+            return AlertRule.builder()
+                    .id(id)
+                    .title(title)
+                    .description(description)
+                    .conditions(conditions)
+                    .recommendation(recommendation)
+                    .costSaving(costSaving)
+                    .build();
+                    
+        } catch (Exception e) {
+            log.error("Failed to parse alert rule: {}", ruleMap, e);
+            return null;
+        }
+    }
+    
+    private AlertCondition parseCondition(Map<String, Object> conditionMap) {
+        try {
+            String metric = (String) conditionMap.get("metric");
+            Object threshold = conditionMap.get("threshold");
+            String period = (String) conditionMap.get("period");
+            String value = (String) conditionMap.get("value");
+            
+            return AlertCondition.builder()
+                    .metric(metric)
+                    .threshold(threshold)
+                    .period(period)
+                    .value(value)
+                    .operator("<")
+                    .build();
+                    
+        } catch (Exception e) {
+            log.error("Failed to parse condition: {}", conditionMap, e);
+            return null;
+        }
+    }
+    
+    public List<AlertRule> getAllRules() {
+        return new ArrayList<>(alertRules);
+    }
+    
+    public AlertRule getRuleById(String ruleId) {
+        return alertRules.stream()
+                .filter(rule -> rule.getId().equals(ruleId))
+                .findFirst()
+                .orElse(null);
+    }
+}
+

--- a/src/main/java/com/budgetops/backend/aws/service/AwsS3RuleLoader.java
+++ b/src/main/java/com/budgetops/backend/aws/service/AwsS3RuleLoader.java
@@ -1,0 +1,129 @@
+package com.budgetops.backend.aws.service;
+
+import com.budgetops.backend.aws.dto.AlertCondition;
+import com.budgetops.backend.aws.dto.AlertRule;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+import org.springframework.stereotype.Component;
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.InputStream;
+import java.util.*;
+
+/**
+ * AWS S3 알림 규칙 로더
+ * csp_aws_s3.yml 파일을 로드하여 알림 규칙 정보 제공
+ */
+@Slf4j
+@Component
+public class AwsS3RuleLoader {
+    
+    private final List<AlertRule> alertRules = new ArrayList<>();
+    private final Yaml yaml = new Yaml();
+    
+    public AwsS3RuleLoader() {
+        loadRules();
+    }
+    
+    private void loadRules() {
+        try {
+            PathMatchingResourcePatternResolver resolver = new PathMatchingResourcePatternResolver();
+            Resource resource = resolver.getResource("classpath:costs/csp_aws_s3.yml");
+            
+            if (!resource.exists()) {
+                log.warn("AWS S3 rule file not found: csp_aws_s3.yml");
+                return;
+            }
+            
+            try (InputStream inputStream = resource.getInputStream()) {
+                Map<String, Object> data = yaml.load(inputStream);
+                
+                @SuppressWarnings("unchecked")
+                List<Map<String, Object>> rulesList = (List<Map<String, Object>>) data.get("rules");
+                
+                if (rulesList != null) {
+                    for (Map<String, Object> ruleMap : rulesList) {
+                        AlertRule rule = parseRule(ruleMap);
+                        if (rule != null) {
+                            alertRules.add(rule);
+                        }
+                    }
+                    
+                    log.info("Loaded {} alert rules for AWS S3", alertRules.size());
+                }
+            }
+        } catch (Exception e) {
+            log.error("Failed to load AWS S3 alert rules", e);
+        }
+    }
+    
+    private AlertRule parseRule(Map<String, Object> ruleMap) {
+        try {
+            String id = (String) ruleMap.get("id");
+            String title = (String) ruleMap.get("title");
+            String description = (String) ruleMap.get("description");
+            String recommendation = (String) ruleMap.get("recommendation");
+            String costSaving = (String) ruleMap.get("cost_saving");
+            
+            @SuppressWarnings("unchecked")
+            List<Map<String, Object>> conditionsList = (List<Map<String, Object>>) ruleMap.get("conditions");
+            
+            List<AlertCondition> conditions = new ArrayList<>();
+            if (conditionsList != null) {
+                for (Map<String, Object> conditionMap : conditionsList) {
+                    AlertCondition condition = parseCondition(conditionMap);
+                    if (condition != null) {
+                        conditions.add(condition);
+                    }
+                }
+            }
+            
+            return AlertRule.builder()
+                    .id(id)
+                    .title(title)
+                    .description(description)
+                    .conditions(conditions)
+                    .recommendation(recommendation)
+                    .costSaving(costSaving)
+                    .build();
+                    
+        } catch (Exception e) {
+            log.error("Failed to parse alert rule: {}", ruleMap, e);
+            return null;
+        }
+    }
+    
+    private AlertCondition parseCondition(Map<String, Object> conditionMap) {
+        try {
+            String metric = (String) conditionMap.get("metric");
+            Object threshold = conditionMap.get("threshold");
+            String period = (String) conditionMap.get("period");
+            String value = (String) conditionMap.get("value");
+            
+            return AlertCondition.builder()
+                    .metric(metric)
+                    .threshold(threshold)
+                    .period(period)
+                    .value(value)
+                    .operator("<")
+                    .build();
+                    
+        } catch (Exception e) {
+            log.error("Failed to parse condition: {}", conditionMap, e);
+            return null;
+        }
+    }
+    
+    public List<AlertRule> getAllRules() {
+        return new ArrayList<>(alertRules);
+    }
+    
+    public AlertRule getRuleById(String ruleId) {
+        return alertRules.stream()
+                .filter(rule -> rule.getId().equals(ruleId))
+                .findFirst()
+                .orElse(null);
+    }
+}
+

--- a/src/main/java/com/budgetops/backend/gcp/controller/GcpAlertController.java
+++ b/src/main/java/com/budgetops/backend/gcp/controller/GcpAlertController.java
@@ -1,0 +1,45 @@
+package com.budgetops.backend.gcp.controller;
+
+import com.budgetops.backend.gcp.dto.GcpAlert;
+import com.budgetops.backend.gcp.service.GcpAlertService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+/**
+ * GCP 알림 API 컨트롤러
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/gcp/alerts")
+@RequiredArgsConstructor
+public class GcpAlertController {
+    
+    private final GcpAlertService alertService;
+    
+    /**
+     * 모든 GCP 계정의 알림 확인 및 발송
+     * POST /api/gcp/alerts/check
+     */
+    @PostMapping("/check")
+    public ResponseEntity<List<GcpAlert>> checkAllAccounts() {
+        log.info("Manual GCP alert check triggered");
+        List<GcpAlert> alerts = alertService.checkAllAccounts();
+        return ResponseEntity.ok(alerts);
+    }
+    
+    /**
+     * 특정 GCP 계정의 알림 확인 및 발송
+     * POST /api/gcp/alerts/check/{accountId}
+     */
+    @PostMapping("/check/{accountId}")
+    public ResponseEntity<List<GcpAlert>> checkAccount(@PathVariable Long accountId) {
+        log.info("Manual GCP alert check triggered for account {}", accountId);
+        List<GcpAlert> alerts = alertService.checkAccount(accountId);
+        return ResponseEntity.ok(alerts);
+    }
+}
+

--- a/src/main/java/com/budgetops/backend/gcp/dto/GcpAlert.java
+++ b/src/main/java/com/budgetops/backend/gcp/dto/GcpAlert.java
@@ -1,0 +1,110 @@
+package com.budgetops.backend.gcp.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * GCP 리소스 알림 정보
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GcpAlert {
+    /**
+     * 알림 ID
+     */
+    private Long id;
+    
+    /**
+     * GCP 계정 ID
+     */
+    private Long accountId;
+    
+    /**
+     * GCP 계정 이름
+     */
+    private String accountName;
+    
+    /**
+     * 리소스 ID
+     */
+    private String resourceId;
+    
+    /**
+     * 리소스 이름
+     */
+    private String resourceName;
+    
+    /**
+     * 규칙 ID
+     */
+    private String ruleId;
+    
+    /**
+     * 규칙 제목
+     */
+    private String ruleTitle;
+    
+    /**
+     * 위반한 조건 메트릭
+     */
+    private String violatedMetric;
+    
+    /**
+     * 현재 값
+     */
+    private Double currentValue;
+    
+    /**
+     * 임계값
+     */
+    private Double threshold;
+    
+    /**
+     * 알림 메시지
+     */
+    private String message;
+    
+    /**
+     * 알림 심각도 (INFO, WARNING, CRITICAL)
+     */
+    private AlertSeverity severity;
+    
+    /**
+     * 알림 상태 (PENDING, SENT, ACKNOWLEDGED)
+     */
+    private AlertStatus status;
+    
+    /**
+     * 알림 생성 시간
+     */
+    private LocalDateTime createdAt;
+    
+    /**
+     * 알림 발송 시간
+     */
+    private LocalDateTime sentAt;
+    
+    /**
+     * 알림 확인 시간
+     */
+    private LocalDateTime acknowledgedAt;
+    
+    public enum AlertSeverity {
+        INFO,
+        WARNING,
+        CRITICAL
+    }
+    
+    public enum AlertStatus {
+        PENDING,
+        SENT,
+        ACKNOWLEDGED
+    }
+}
+

--- a/src/main/java/com/budgetops/backend/gcp/service/GcpAlertService.java
+++ b/src/main/java/com/budgetops/backend/gcp/service/GcpAlertService.java
@@ -1,0 +1,319 @@
+package com.budgetops.backend.gcp.service;
+
+import com.budgetops.backend.aws.dto.AlertCondition;
+import com.budgetops.backend.aws.dto.AlertRule;
+import com.budgetops.backend.gcp.dto.GcpAlert;
+import com.budgetops.backend.gcp.dto.GcpResourceResponse;
+import com.budgetops.backend.gcp.entity.GcpAccount;
+import com.budgetops.backend.gcp.repository.GcpAccountRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * GCP 리소스 사용량 임계치 초과 시 알림 발송 서비스
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GcpAlertService {
+    
+    private final GcpAccountRepository accountRepository;
+    private final GcpResourceService resourceService;
+    private final GcpRuleLoader ruleLoader;
+    
+    /**
+     * 모든 활성 GCP 계정의 리소스에 대해 임계치 확인 및 알림 발송
+     */
+    public List<GcpAlert> checkAllAccounts() {
+        List<GcpAccount> activeAccounts = accountRepository.findByActiveTrue();
+        log.info("Checking thresholds for {} active GCP account(s)", activeAccounts.size());
+        
+        List<GcpAlert> allAlerts = new ArrayList<>();
+        
+        for (GcpAccount account : activeAccounts) {
+            try {
+                List<GcpAlert> accountAlerts = checkAccount(account.getId());
+                allAlerts.addAll(accountAlerts);
+            } catch (Exception e) {
+                log.error("Failed to check account {}: {}", account.getId(), e.getMessage(), e);
+            }
+        }
+        
+        log.info("Total {} GCP alerts generated", allAlerts.size());
+        return allAlerts;
+    }
+    
+    /**
+     * 특정 GCP 계정의 리소스에 대해 임계치 확인 및 알림 발송
+     */
+    public List<GcpAlert> checkAccount(Long accountId) {
+        GcpAccount account = accountRepository.findById(accountId)
+                .orElseThrow(() -> new IllegalArgumentException("GCP 계정을 찾을 수 없습니다: " + accountId));
+        
+        if (!Boolean.TRUE.equals(account.getActive())) {
+            log.warn("Account {} is not active, skipping alert check", accountId);
+            return new ArrayList<>();
+        }
+        
+        log.info("Checking thresholds for account {} ({})", accountId, account.getAccountName());
+        
+        // GCP 리소스 목록 조회
+        List<GcpResourceResponse> resources;
+        try {
+            resources = resourceService.getResources(accountId);
+        } catch (Exception e) {
+            log.error("Failed to fetch GCP resources for account {}: {}", accountId, e.getMessage());
+            return new ArrayList<>();
+        }
+        
+        // 모든 규칙 로드
+        List<AlertRule> rules = ruleLoader.getAllRules();
+        
+        List<GcpAlert> alerts = new ArrayList<>();
+        
+        for (GcpResourceResponse resource : resources) {
+            // 실행 중인 인스턴스만 체크
+            if (!"RUNNING".equalsIgnoreCase(resource.getStatus())) {
+                continue;
+            }
+            
+            for (AlertRule rule : rules) {
+                List<GcpAlert> ruleAlerts = checkRule(account, resource, rule);
+                alerts.addAll(ruleAlerts);
+            }
+        }
+        
+        // 알림 발송
+        for (GcpAlert alert : alerts) {
+            sendAlert(alert);
+        }
+        
+        log.info("Generated {} GCP alerts for account {}", alerts.size(), accountId);
+        return alerts;
+    }
+    
+    /**
+     * 특정 리소스와 규칙에 대해 임계치 확인
+     */
+    private List<GcpAlert> checkRule(GcpAccount account, GcpResourceResponse resource, AlertRule rule) {
+        List<GcpAlert> alerts = new ArrayList<>();
+        
+        try {
+            // 모든 조건이 만족되는지 확인
+            boolean allConditionsMet = true;
+            String violatedMetric = null;
+            Double currentValue = null;
+            Double threshold = null;
+            
+            for (AlertCondition condition : rule.getConditions()) {
+                MetricCheckResult result = checkCondition(account, resource, condition);
+                
+                if (!result.isViolated()) {
+                    allConditionsMet = false;
+                    break;
+                }
+                
+                // 위반한 조건 정보 저장 (첫 번째 위반 조건)
+                if (violatedMetric == null) {
+                    violatedMetric = condition.getMetric();
+                    currentValue = result.getCurrentValue();
+                    threshold = result.getThreshold();
+                }
+            }
+            
+            // 모든 조건이 만족되면 알림 생성
+            if (allConditionsMet) {
+                GcpAlert alert = createAlert(account, resource, rule, violatedMetric, currentValue, threshold);
+                alerts.add(alert);
+            }
+            
+        } catch (Exception e) {
+            log.error("Failed to check rule {} for resource {}: {}", 
+                    rule.getId(), resource.getResourceId(), e.getMessage(), e);
+        }
+        
+        return alerts;
+    }
+    
+    /**
+     * 특정 조건에 대해 메트릭 확인
+     */
+    private MetricCheckResult checkCondition(GcpAccount account, GcpResourceResponse resource, AlertCondition condition) {
+        String metric = condition.getMetric();
+        
+        try {
+            // 현재는 리소스 정보에서 메트릭을 추출 (추후 Cloud Monitoring API 연동 가능)
+            double averageValue = 0.0;
+            boolean hasData = false;
+            
+            // TODO: Cloud Monitoring API 연동하여 실제 메트릭 조회
+            // 현재는 mock 데이터로 처리
+            switch (metric) {
+                case "cpu_utilization":
+                    // 임시: 랜덤 값 (실제로는 Cloud Monitoring에서 조회)
+                    averageValue = Math.random() * 100;
+                    hasData = true;
+                    break;
+                    
+                case "memory_utilization":
+                    averageValue = Math.random() * 100;
+                    hasData = true;
+                    break;
+                    
+                case "network_in":
+                    averageValue = Math.random() * 10;
+                    hasData = true;
+                    break;
+                    
+                default:
+                    log.warn("Unknown metric: {}", metric);
+                    return MetricCheckResult.notViolated();
+            }
+            
+            if (!hasData) {
+                return MetricCheckResult.notViolated();
+            }
+            
+            // 임계값과 비교
+            Double threshold = condition.getThresholdAsDouble();
+            if (threshold == null) {
+                return MetricCheckResult.notViolated();
+            }
+            
+            // 기본 연산자는 < (미만), 즉 현재값이 임계값보다 작으면 위반
+            boolean violated = averageValue < threshold;
+            
+            if (violated) {
+                return MetricCheckResult.violated(averageValue, threshold);
+            } else {
+                return MetricCheckResult.notViolated();
+            }
+            
+        } catch (Exception e) {
+            log.error("Failed to check condition {} for resource {}: {}", 
+                    metric, resource.getResourceId(), e.getMessage());
+            return MetricCheckResult.notViolated();
+        }
+    }
+    
+    /**
+     * 알림 생성
+     */
+    private GcpAlert createAlert(GcpAccount account, GcpResourceResponse resource, 
+                                   AlertRule rule, String violatedMetric, 
+                                   Double currentValue, Double threshold) {
+        
+        // 심각도 결정
+        GcpAlert.AlertSeverity severity = determineSeverity(violatedMetric, currentValue, threshold);
+        
+        // 알림 메시지 생성
+        String message = String.format(
+                "[%s] 리소스 %s(%s)에서 규칙 '%s' 위반 감지.\n" +
+                "메트릭: %s, 현재값: %.2f, 임계값: %.2f\n" +
+                "%s",
+                account.getAccountName(),
+                resource.getResourceName(),
+                resource.getResourceId(),
+                rule.getTitle(),
+                violatedMetric,
+                currentValue != null ? currentValue : 0.0,
+                threshold != null ? threshold : 0.0,
+                rule.getRecommendation()
+        );
+        
+        return GcpAlert.builder()
+                .accountId(account.getId())
+                .accountName(account.getAccountName())
+                .resourceId(resource.getResourceId())
+                .resourceName(resource.getResourceName())
+                .ruleId(rule.getId())
+                .ruleTitle(rule.getTitle())
+                .violatedMetric(violatedMetric)
+                .currentValue(currentValue)
+                .threshold(threshold)
+                .message(message)
+                .severity(severity)
+                .status(GcpAlert.AlertStatus.PENDING)
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+    
+    /**
+     * 심각도 결정
+     */
+    private GcpAlert.AlertSeverity determineSeverity(String metric, Double currentValue, Double threshold) {
+        if (currentValue == null || threshold == null) {
+            return GcpAlert.AlertSeverity.WARNING;
+        }
+        
+        // 임계값 대비 현재값 비율
+        double ratio = threshold > 0 ? (currentValue / threshold) * 100 : 0;
+        
+        // 임계값보다 50% 이상 낮으면 CRITICAL (심각한 낭비)
+        if (ratio < 50) {
+            return GcpAlert.AlertSeverity.CRITICAL;
+        } else if (ratio < 70) {
+            return GcpAlert.AlertSeverity.WARNING;
+        } else {
+            return GcpAlert.AlertSeverity.INFO;
+        }
+    }
+    
+    /**
+     * 알림 발송
+     */
+    private void sendAlert(GcpAlert alert) {
+        try {
+            log.warn("🚨 GCP Alert: {}", alert.getMessage());
+            
+            alert.setStatus(GcpAlert.AlertStatus.SENT);
+            alert.setSentAt(LocalDateTime.now());
+            
+            // TODO: 실제 알림 발송 로직 (이메일, 슬랙, 웹훅 등)
+            
+        } catch (Exception e) {
+            log.error("Failed to send alert: {}", alert.getMessage(), e);
+        }
+    }
+    
+    /**
+     * 메트릭 확인 결과
+     */
+    private static class MetricCheckResult {
+        private final boolean violated;
+        private final Double currentValue;
+        private final Double threshold;
+        
+        private MetricCheckResult(boolean violated, Double currentValue, Double threshold) {
+            this.violated = violated;
+            this.currentValue = currentValue;
+            this.threshold = threshold;
+        }
+        
+        public static MetricCheckResult violated(double currentValue, double threshold) {
+            return new MetricCheckResult(true, currentValue, threshold);
+        }
+        
+        public static MetricCheckResult notViolated() {
+            return new MetricCheckResult(false, null, null);
+        }
+        
+        public boolean isViolated() {
+            return violated;
+        }
+        
+        public Double getCurrentValue() {
+            return currentValue;
+        }
+        
+        public Double getThreshold() {
+            return threshold;
+        }
+    }
+}
+

--- a/src/main/java/com/budgetops/backend/gcp/service/GcpRuleLoader.java
+++ b/src/main/java/com/budgetops/backend/gcp/service/GcpRuleLoader.java
@@ -1,0 +1,129 @@
+package com.budgetops.backend.gcp.service;
+
+import com.budgetops.backend.aws.dto.AlertCondition;
+import com.budgetops.backend.aws.dto.AlertRule;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+import org.springframework.stereotype.Component;
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.InputStream;
+import java.util.*;
+
+/**
+ * GCP Compute Engine 알림 규칙 로더
+ * csp_gcp_compute.yml 파일을 로드하여 알림 규칙 정보 제공
+ */
+@Slf4j
+@Component
+public class GcpRuleLoader {
+    
+    private final List<AlertRule> alertRules = new ArrayList<>();
+    private final Yaml yaml = new Yaml();
+    
+    public GcpRuleLoader() {
+        loadRules();
+    }
+    
+    private void loadRules() {
+        try {
+            PathMatchingResourcePatternResolver resolver = new PathMatchingResourcePatternResolver();
+            Resource resource = resolver.getResource("classpath:costs/csp_gcp_compute.yml");
+            
+            if (!resource.exists()) {
+                log.warn("GCP Compute rule file not found: csp_gcp_compute.yml");
+                return;
+            }
+            
+            try (InputStream inputStream = resource.getInputStream()) {
+                Map<String, Object> data = yaml.load(inputStream);
+                
+                @SuppressWarnings("unchecked")
+                List<Map<String, Object>> rulesList = (List<Map<String, Object>>) data.get("rules");
+                
+                if (rulesList != null) {
+                    for (Map<String, Object> ruleMap : rulesList) {
+                        AlertRule rule = parseRule(ruleMap);
+                        if (rule != null) {
+                            alertRules.add(rule);
+                        }
+                    }
+                    
+                    log.info("Loaded {} alert rules for GCP Compute Engine", alertRules.size());
+                }
+            }
+        } catch (Exception e) {
+            log.error("Failed to load GCP Compute alert rules", e);
+        }
+    }
+    
+    private AlertRule parseRule(Map<String, Object> ruleMap) {
+        try {
+            String id = (String) ruleMap.get("id");
+            String title = (String) ruleMap.get("title");
+            String description = (String) ruleMap.get("description");
+            String recommendation = (String) ruleMap.get("recommendation");
+            String costSaving = (String) ruleMap.get("cost_saving");
+            
+            @SuppressWarnings("unchecked")
+            List<Map<String, Object>> conditionsList = (List<Map<String, Object>>) ruleMap.get("conditions");
+            
+            List<AlertCondition> conditions = new ArrayList<>();
+            if (conditionsList != null) {
+                for (Map<String, Object> conditionMap : conditionsList) {
+                    AlertCondition condition = parseCondition(conditionMap);
+                    if (condition != null) {
+                        conditions.add(condition);
+                    }
+                }
+            }
+            
+            return AlertRule.builder()
+                    .id(id)
+                    .title(title)
+                    .description(description)
+                    .conditions(conditions)
+                    .recommendation(recommendation)
+                    .costSaving(costSaving)
+                    .build();
+                    
+        } catch (Exception e) {
+            log.error("Failed to parse alert rule: {}", ruleMap, e);
+            return null;
+        }
+    }
+    
+    private AlertCondition parseCondition(Map<String, Object> conditionMap) {
+        try {
+            String metric = (String) conditionMap.get("metric");
+            Object threshold = conditionMap.get("threshold");
+            String period = (String) conditionMap.get("period");
+            String value = (String) conditionMap.get("value");
+            
+            return AlertCondition.builder()
+                    .metric(metric)
+                    .threshold(threshold)
+                    .period(period)
+                    .value(value)
+                    .operator("<")
+                    .build();
+                    
+        } catch (Exception e) {
+            log.error("Failed to parse condition: {}", conditionMap, e);
+            return null;
+        }
+    }
+    
+    public List<AlertRule> getAllRules() {
+        return new ArrayList<>(alertRules);
+    }
+    
+    public AlertRule getRuleById(String ruleId) {
+        return alertRules.stream()
+                .filter(rule -> rule.getId().equals(ruleId))
+                .findFirst()
+                .orElse(null);
+    }
+}
+


### PR DESCRIPTION
## Feature/18 GCP Compute Engine 리소스 알림 시스템 구현

### 개요
GCP Compute Engine 인스턴스의 리소스 사용량을 모니터링하고, **YAML 기반 규칙**으로 임계치를 평가하여 **알림을 생성·발송**하는 기능을 구현함. AWS 알림 시스템과 동일한 구조로 확장하여 **통합 알림 센터**에서 함께 조회 가능하도록 구성됨.

---

### 백엔드 변경사항

#### 1. GCP 알림 시스템 구성
- **GcpAlert**  
  GCP 알림 정보를 담는 DTO  
  (인스턴스 ID, 프로젝트, 위반 메트릭, 심각도 등)

- **GcpRuleLoader**  
  `csp_gcp_compute.yml` 파싱하여 규칙(rule) 및 조건(condition) 로드

- **GcpAlertService**  
  - GCP Compute Engine 사용량 조회  
  - 규칙 비교  
  - 임계치 초과 시 GcpAlert 생성  
  - (현재 메트릭은 임시 데이터, Cloud Monitoring API 연동 예정)

- **GcpAlertController**
   - POST /api/gcp/alerts/check
   - 전체 계정 대상 GCP 알림 검사 수행

#### 2. 지원 메트릭 (임시 데이터 기반)
- CPU 사용률 (CPUUtilization)
- 메모리 사용률 (MemoryUtilization)
- 네트워크 트래픽 (NetworkIn / NetworkOut)

---

### 프론트엔드 변경사항

#### 1. GCP 알림 통합
- **GcpAlert 타입** 추가
- **checkGcpAlerts() API 함수** 구현
- 알림 센터에 GCP 알림 자동 집계
- AWS와 구분을 위해 **파란색 배지** 적용

#### 2. 통합 알림 센터 개선
- AWS + GCP 알림을 단일 목록으로 표시
- 제공자(Provider)별 색상 태그 적용
- 심각도(CRITICAL → WARNING → INFO) 우선 정렬

---

### 기대 효과
- AWS와 동일한 구조의 GCP 알림 시스템 제공  
- 멀티 클라우드 환경에서 통합 모니터링 가능  
- 향후 Cloud Monitoring API와 연동 시 실제 메트릭 기반 알림으로 확장 가능  
