### PR TITLE
feat: NCP 비용 요약 조회 API 추가 및 리팩토링

### DIFF
--- a/src/main/java/com/budgetops/backend/ncp/controller/NcpAccountController.java
+++ b/src/main/java/com/budgetops/backend/ncp/controller/NcpAccountController.java
@@ -2,6 +2,7 @@ package com.budgetops.backend.ncp.controller;
 
 import com.budgetops.backend.ncp.dto.NcpAccountCreateRequest;
 import com.budgetops.backend.ncp.dto.NcpAccountResponse;
+import com.budgetops.backend.ncp.dto.NcpCostSummary;
 import com.budgetops.backend.ncp.dto.NcpDailyUsage;
 import com.budgetops.backend.ncp.dto.NcpMonthlyCost;
 import com.budgetops.backend.ncp.entity.NcpAccount;
@@ -77,16 +78,25 @@ public class NcpAccountController {
             @RequestParam(required = false) String startMonth,
             @RequestParam(required = false) String endMonth
     ) {
-        // 기본값: 최근 3개월
-        if (startMonth == null) {
-            startMonth = LocalDate.now().minusMonths(2).format(DateTimeFormatter.ofPattern("yyyyMM"));
-        }
-        if (endMonth == null) {
-            endMonth = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMM"));
-        }
+        String start = getDefaultMonthIfNull(startMonth, -2);
+        String end = getDefaultMonthIfNull(endMonth, 0);
 
-        List<NcpMonthlyCost> costs = costService.getCosts(accountId, startMonth, endMonth);
+        List<NcpMonthlyCost> costs = costService.getCosts(accountId, start, end);
         return ResponseEntity.ok(costs);
+    }
+
+    /**
+     * 특정 계정의 월별 비용 요약 조회
+     */
+    @GetMapping("/{accountId}/costs/summary")
+    public ResponseEntity<NcpCostSummary> getAccountCostSummary(
+            @PathVariable Long accountId,
+            @RequestParam(required = false) String month
+    ) {
+        String targetMonth = getDefaultMonthIfNull(month, 0);
+
+        NcpCostSummary summary = costService.getCostSummary(accountId, targetMonth);
+        return ResponseEntity.ok(summary);
     }
 
     /**
@@ -98,16 +108,40 @@ public class NcpAccountController {
             @RequestParam(required = false) String startDay,
             @RequestParam(required = false) String endDay
     ) {
-        // 기본값: 이번 달 1일 ~ 오늘
-        if (startDay == null) {
-            startDay = LocalDate.now().withDayOfMonth(1).format(DateTimeFormatter.ofPattern("yyyyMMdd"));
-        }
-        if (endDay == null) {
-            endDay = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"));
-        }
+        String start = getDefaultDayIfNull(startDay, true);
+        String end = getDefaultDayIfNull(endDay, false);
 
-        List<NcpDailyUsage> usageList = costService.getDailyUsage(accountId, startDay, endDay);
+        List<NcpDailyUsage> usageList = costService.getDailyUsage(accountId, start, end);
         return ResponseEntity.ok(usageList);
+    }
+
+    /**
+     * null인 경우 기본 월(YYYYMM) 반환
+     *
+     * @param month 월 문자열
+     * @param monthOffset 현재 월 기준 오프셋 (음수 가능)
+     * @return YYYYMM 형식 문자열
+     */
+    private String getDefaultMonthIfNull(String month, int monthOffset) {
+        if (month != null) {
+            return month;
+        }
+        return LocalDate.now().plusMonths(monthOffset).format(DateTimeFormatter.ofPattern("yyyyMM"));
+    }
+
+    /**
+     * null인 경우 기본 일(YYYYMMDD) 반환
+     *
+     * @param day 일 문자열
+     * @param isFirstDayOfMonth true면 이번 달 1일, false면 오늘
+     * @return YYYYMMDD 형식 문자열
+     */
+    private String getDefaultDayIfNull(String day, boolean isFirstDayOfMonth) {
+        if (day != null) {
+            return day;
+        }
+        LocalDate date = isFirstDayOfMonth ? LocalDate.now().withDayOfMonth(1) : LocalDate.now();
+        return date.format(DateTimeFormatter.ofPattern("yyyyMMdd"));
     }
 
     /**

--- a/src/main/java/com/budgetops/backend/ncp/dto/NcpCostSummary.java
+++ b/src/main/java/com/budgetops/backend/ncp/dto/NcpCostSummary.java
@@ -1,0 +1,43 @@
+package com.budgetops.backend.ncp.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * NCP 비용 요약 정보
+ */
+@Getter
+@Setter
+@Builder
+public class NcpCostSummary {
+    /**
+     * 조회 월 (YYYYMM 형식)
+     */
+    private String month;
+
+    /**
+     * 총 비용
+     */
+    private Double totalCost;
+
+    /**
+     * 통화
+     */
+    private String currency;
+
+    /**
+     * 총 청구 금액 (demandAmount 합계)
+     */
+    private Double totalDemandAmount;
+
+    /**
+     * 총 사용 금액 (useAmount 합계)
+     */
+    private Double totalUseAmount;
+
+    /**
+     * 총 할인 금액
+     */
+    private Double totalDiscountAmount;
+}

--- a/src/main/java/com/budgetops/backend/ncp/service/NcpCostService.java
+++ b/src/main/java/com/budgetops/backend/ncp/service/NcpCostService.java
@@ -1,6 +1,7 @@
 package com.budgetops.backend.ncp.service;
 
 import com.budgetops.backend.ncp.client.NcpApiClient;
+import com.budgetops.backend.ncp.dto.NcpCostSummary;
 import com.budgetops.backend.ncp.dto.NcpDailyUsage;
 import com.budgetops.backend.ncp.dto.NcpMonthlyCost;
 import com.budgetops.backend.ncp.entity.NcpAccount;
@@ -58,6 +59,87 @@ public class NcpCostService {
         } catch (Exception e) {
             log.error("Failed to fetch costs for account {} from {} to {}: {}", accountId, startMonth, endMonth, e.getMessage(), e);
             throw new RuntimeException("비용 조회 실패: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * NCP 계정의 월별 비용 요약 조회
+     *
+     * @param accountId NCP 계정 ID
+     * @param month 조회 월 (YYYYMM 형식, 예: 202401)
+     * @return 비용 요약 정보
+     */
+    public NcpCostSummary getCostSummary(Long accountId, String month) {
+        List<NcpMonthlyCost> costs = getCosts(accountId, month, month);
+
+        CostAggregation aggregation = aggregateCosts(costs);
+
+        log.info("Cost summary for account {} month {}: total={}, discount={}",
+                accountId, month, aggregation.totalDemandAmount, aggregation.totalDiscount);
+
+        return NcpCostSummary.builder()
+                .month(month)
+                .totalCost(aggregation.totalDemandAmount)
+                .currency(aggregation.currency)
+                .totalDemandAmount(aggregation.totalDemandAmount)
+                .totalUseAmount(aggregation.totalUseAmount)
+                .totalDiscountAmount(aggregation.totalDiscount)
+                .build();
+    }
+
+    /**
+     * 비용 목록을 집계
+     *
+     * @param costs 비용 목록
+     * @return 집계 결과
+     */
+    private CostAggregation aggregateCosts(List<NcpMonthlyCost> costs) {
+        double totalDemandAmount = 0.0;
+        double totalUseAmount = 0.0;
+        double totalPromotionDiscount = 0.0;
+        double totalEtcDiscount = 0.0;
+        String currency = "KRW";
+
+        for (NcpMonthlyCost cost : costs) {
+            totalDemandAmount += getAmountOrZero(cost.getDemandAmount());
+            totalUseAmount += getAmountOrZero(cost.getUseAmount());
+            totalPromotionDiscount += getAmountOrZero(cost.getPromotionDiscountAmount());
+            totalEtcDiscount += getAmountOrZero(cost.getEtcDiscountAmount());
+
+            if (cost.getCurrency() != null && !cost.getCurrency().isEmpty()) {
+                currency = cost.getCurrency();
+            }
+        }
+
+        return new CostAggregation(
+                totalDemandAmount,
+                totalUseAmount,
+                totalPromotionDiscount + totalEtcDiscount,
+                currency
+        );
+    }
+
+    /**
+     * null-safe 금액 반환
+     */
+    private double getAmountOrZero(Double amount) {
+        return amount != null ? amount : 0.0;
+    }
+
+    /**
+     * 비용 집계 결과를 담는 내부 클래스
+     */
+    private static class CostAggregation {
+        final double totalDemandAmount;
+        final double totalUseAmount;
+        final double totalDiscount;
+        final String currency;
+
+        CostAggregation(double totalDemandAmount, double totalUseAmount, double totalDiscount, String currency) {
+            this.totalDemandAmount = totalDemandAmount;
+            this.totalUseAmount = totalUseAmount;
+            this.totalDiscount = totalDiscount;
+            this.currency = currency;
         }
     }
 


### PR DESCRIPTION
- NCP 계정별 월별 비용 요약 조회 API 추가
  - GET /api/ncp/accounts/{accountId}/costs/summary
  - 총 비용, 청구 금액, 사용 금액, 할인 금액 제공
  - 기본값: 현재 월

- NcpCostService 리팩토링
  - 비용 집계 로직을 aggregateCosts() 메서드로 분리
  - CostAggregation 내부 클래스 추가로 결과 명확화
  - getAmountOrZero() 헬퍼 메서드로 null-safe 처리 통일

- NcpAccountController 리팩토링
  - 날짜 기본값 설정 로직을 헬퍼 메서드로 통합
  - getDefaultMonthIfNull(), getDefaultDayIfNull() 추가
  - 코드 중복 제거 및 가독성 향상

- NcpCostSummary DTO 추가
  - 월별 비용 요약 정보 표현
  - Builder 패턴 적용