### PR TITLE
Feature/21: 예산 설정 및 대시보드 조회 가능

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,7 @@
 name: backend-deploy
 on:
   push:
-    branches: [ main, develop, feature/db ]
+    branches: [ main, develop, feature/21 ]
   pull_request:
     branches: [ develop, main ]              # PR 때 빌드만
   workflow_dispatch: { }

--- a/src/main/java/com/budgetops/backend/billing/repository/BillingRepository.java
+++ b/src/main/java/com/budgetops/backend/billing/repository/BillingRepository.java
@@ -12,5 +12,7 @@ public interface BillingRepository extends JpaRepository<Billing, Long> {
 
     Optional<Billing> findByMember(Member member);
 
+    Optional<Billing> findByMemberId(Long memberId);
+
     boolean existsByMember(Member member);
 }

--- a/src/main/java/com/budgetops/backend/budget/controller/BudgetController.java
+++ b/src/main/java/com/budgetops/backend/budget/controller/BudgetController.java
@@ -1,0 +1,55 @@
+package com.budgetops.backend.budget.controller;
+
+import com.budgetops.backend.budget.dto.BudgetAlertResponse;
+import com.budgetops.backend.budget.dto.BudgetSettingsRequest;
+import com.budgetops.backend.budget.dto.BudgetSettingsResponse;
+import com.budgetops.backend.budget.dto.BudgetUsageResponse;
+import com.budgetops.backend.budget.service.BudgetService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/budgets")
+@RequiredArgsConstructor
+public class BudgetController {
+
+    private final BudgetService budgetService;
+
+    @GetMapping("/me/settings")
+    public ResponseEntity<BudgetSettingsResponse> getSettings() {
+        return ResponseEntity.ok(budgetService.getSettings(getCurrentMemberId()));
+    }
+
+    @PutMapping("/me/settings")
+    public ResponseEntity<BudgetSettingsResponse> updateSettings(
+            @Valid @RequestBody BudgetSettingsRequest request
+    ) {
+        return ResponseEntity.ok(budgetService.updateSettings(getCurrentMemberId(), request));
+    }
+
+    @GetMapping("/me/usage")
+    public ResponseEntity<BudgetUsageResponse> getUsage() {
+        return ResponseEntity.ok(budgetService.getUsage(getCurrentMemberId()));
+    }
+
+    @PostMapping("/alerts/check")
+    public ResponseEntity<List<BudgetAlertResponse>> checkAlerts() {
+        return ResponseEntity.ok(
+                budgetService.checkAlert(getCurrentMemberId())
+                        .map(List::of)
+                        .orElse(List.of())
+        );
+    }
+
+    private Long getCurrentMemberId() {
+        return (Long) SecurityContextHolder.getContext()
+                .getAuthentication()
+                .getPrincipal();
+    }
+}
+

--- a/src/main/java/com/budgetops/backend/budget/dto/BudgetAlertResponse.java
+++ b/src/main/java/com/budgetops/backend/budget/dto/BudgetAlertResponse.java
@@ -1,0 +1,17 @@
+package com.budgetops.backend.budget.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+public record BudgetAlertResponse(
+        BigDecimal budgetLimit,
+        BigDecimal currentMonthCost,
+        double usagePercentage,
+        int threshold,
+        String month,
+        String currency,
+        LocalDateTime triggeredAt,
+        String message
+) {
+}
+

--- a/src/main/java/com/budgetops/backend/budget/dto/BudgetSettingsRequest.java
+++ b/src/main/java/com/budgetops/backend/budget/dto/BudgetSettingsRequest.java
@@ -1,0 +1,23 @@
+package com.budgetops.backend.budget.dto;
+
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Digits;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+import java.math.BigDecimal;
+
+public record BudgetSettingsRequest(
+        @NotNull(message = "예산 한도를 입력해주세요.")
+        @DecimalMin(value = "0.0", inclusive = true, message = "예산 한도는 0 이상이어야 합니다.")
+        @Digits(integer = 15, fraction = 2, message = "예산 한도는 소수점 둘째 자리까지 입력 가능합니다.")
+        BigDecimal monthlyBudgetLimit,
+
+        @NotNull(message = "알림 임계값을 선택해주세요.")
+        @Min(value = 0, message = "알림 임계값은 0 이상이어야 합니다.")
+        @Max(value = 100, message = "알림 임계값은 100 이하이어야 합니다.")
+        Integer alertThreshold
+) {
+}
+

--- a/src/main/java/com/budgetops/backend/budget/dto/BudgetSettingsResponse.java
+++ b/src/main/java/com/budgetops/backend/budget/dto/BudgetSettingsResponse.java
@@ -1,0 +1,12 @@
+package com.budgetops.backend.budget.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+public record BudgetSettingsResponse(
+        BigDecimal monthlyBudgetLimit,
+        Integer alertThreshold,
+        LocalDateTime updatedAt
+) {
+}
+

--- a/src/main/java/com/budgetops/backend/budget/dto/BudgetUsageResponse.java
+++ b/src/main/java/com/budgetops/backend/budget/dto/BudgetUsageResponse.java
@@ -1,0 +1,15 @@
+package com.budgetops.backend.budget.dto;
+
+import java.math.BigDecimal;
+
+public record BudgetUsageResponse(
+        BigDecimal monthlyBudgetLimit,
+        Integer alertThreshold,
+        BigDecimal currentMonthCost,
+        double usagePercentage,
+        boolean thresholdReached,
+        String month,
+        String currency
+) {
+}
+

--- a/src/main/java/com/budgetops/backend/budget/service/BudgetService.java
+++ b/src/main/java/com/budgetops/backend/budget/service/BudgetService.java
@@ -1,0 +1,167 @@
+package com.budgetops.backend.budget.service;
+
+import com.budgetops.backend.budget.dto.BudgetAlertResponse;
+import com.budgetops.backend.budget.dto.BudgetSettingsRequest;
+import com.budgetops.backend.budget.dto.BudgetSettingsResponse;
+import com.budgetops.backend.budget.dto.BudgetUsageResponse;
+import com.budgetops.backend.domain.user.entity.Member;
+import com.budgetops.backend.domain.user.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class BudgetService {
+
+    private static final DateTimeFormatter MONTH_KEY = DateTimeFormatter.ofPattern("yyyyMM");
+
+    private final MemberRepository memberRepository;
+    private final CloudCostAggregator cloudCostAggregator;
+
+    @Transactional(readOnly = true)
+    public BudgetSettingsResponse getSettings(Long memberId) {
+        Member member = getMember(memberId);
+        return new BudgetSettingsResponse(
+                member.getMonthlyBudgetLimit(),
+                member.getBudgetAlertThreshold(),
+                member.getUpdatedAt()
+        );
+    }
+
+    @Transactional
+    public BudgetSettingsResponse updateSettings(Long memberId, BudgetSettingsRequest request) {
+        Member member = getMember(memberId);
+        member.setMonthlyBudgetLimit(
+                request.monthlyBudgetLimit().setScale(2, RoundingMode.HALF_UP)
+        );
+        member.setBudgetAlertThreshold(request.alertThreshold());
+        member.setBudgetAlertTriggeredAt(null); // 설정 변경 시 알림 재활성화
+        Member saved = memberRepository.save(member);
+        return new BudgetSettingsResponse(
+                saved.getMonthlyBudgetLimit(),
+                saved.getBudgetAlertThreshold(),
+                saved.getUpdatedAt()
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public BudgetUsageResponse getUsage(Long memberId) {
+        Member member = getMember(memberId);
+        return computeUsage(member).usage();
+    }
+
+    @Transactional
+    public Optional<BudgetAlertResponse> checkAlert(Long memberId) {
+        Member member = getMember(memberId);
+        UsageComputation computation = computeUsage(member);
+        BudgetUsageResponse usage = computation.usage();
+        resetAlertIfNewMonth(member, usage.month());
+
+        if (!usage.thresholdReached()) {
+            return Optional.empty();
+        }
+
+        if (alreadyTriggeredThisMonth(member, usage.month())) {
+            return Optional.empty();
+        }
+
+        member.setBudgetAlertTriggeredAt(LocalDateTime.now());
+        memberRepository.save(member);
+        log.info("Budget alert triggered for member {} usage={}%", memberId, usage.usagePercentage());
+
+        BudgetAlertResponse response = new BudgetAlertResponse(
+                usage.monthlyBudgetLimit(),
+                usage.currentMonthCost(),
+                usage.usagePercentage(),
+                usage.alertThreshold() == null ? 0 : usage.alertThreshold(),
+                usage.month(),
+                usage.currency(),
+                member.getBudgetAlertTriggeredAt(),
+                buildAlertMessage(usage)
+        );
+        return Optional.of(response);
+    }
+
+    private UsageComputation computeUsage(Member member) {
+        CloudCostAggregator.CloudCostSnapshot snapshot = cloudCostAggregator.calculateCurrentMonth(member.getId());
+        BigDecimal budget = normalizeBudget(member.getMonthlyBudgetLimit());
+        Integer threshold = member.getBudgetAlertThreshold();
+        BigDecimal totalCost = snapshot.totalKrw().setScale(2, RoundingMode.HALF_UP);
+
+        double usagePercentage = 0.0;
+        if (budget.compareTo(BigDecimal.ZERO) > 0) {
+            usagePercentage = totalCost
+                    .divide(budget, 4, RoundingMode.HALF_UP)
+                    .multiply(BigDecimal.valueOf(100))
+                    .doubleValue();
+        }
+
+        boolean thresholdReached = threshold != null && threshold > 0 && usagePercentage >= threshold;
+
+        BudgetUsageResponse usageResponse = new BudgetUsageResponse(
+                budget,
+                threshold,
+                totalCost,
+                usagePercentage,
+                thresholdReached,
+                snapshot.month(),
+                "KRW"
+        );
+        return new UsageComputation(usageResponse, snapshot);
+    }
+
+    private String buildAlertMessage(BudgetUsageResponse usage) {
+        return String.format(
+                "이번 달 비용이 설정한 예산의 %.1f%%에 도달했습니다. (임계값 %d%%)",
+                usage.usagePercentage(),
+                usage.alertThreshold()
+        );
+    }
+
+    private void resetAlertIfNewMonth(Member member, String currentMonth) {
+        if (member.getBudgetAlertTriggeredAt() == null) {
+            return;
+        }
+        String triggeredMonth = member.getBudgetAlertTriggeredAt().format(MONTH_KEY);
+        if (!triggeredMonth.equals(currentMonth)) {
+            member.setBudgetAlertTriggeredAt(null);
+            memberRepository.save(member);
+        }
+    }
+
+    private boolean alreadyTriggeredThisMonth(Member member, String currentMonth) {
+        if (member.getBudgetAlertTriggeredAt() == null) {
+            return false;
+        }
+        String triggeredMonth = member.getBudgetAlertTriggeredAt().format(MONTH_KEY);
+        return triggeredMonth.equals(currentMonth);
+    }
+
+    private Member getMember(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("Member not found: " + memberId));
+    }
+
+    private BigDecimal normalizeBudget(BigDecimal budget) {
+        if (budget == null) {
+            return BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP);
+        }
+        return budget.setScale(2, RoundingMode.HALF_UP);
+    }
+
+    private record UsageComputation(
+            BudgetUsageResponse usage,
+            CloudCostAggregator.CloudCostSnapshot snapshot
+    ) {
+    }
+}
+

--- a/src/main/java/com/budgetops/backend/budget/service/CloudCostAggregator.java
+++ b/src/main/java/com/budgetops/backend/budget/service/CloudCostAggregator.java
@@ -1,0 +1,105 @@
+package com.budgetops.backend.budget.service;
+
+import com.budgetops.backend.azure.service.AzureCostService;
+import com.budgetops.backend.aws.service.AwsCostService;
+import com.budgetops.backend.gcp.service.GcpCostService;
+import com.budgetops.backend.ncp.service.NcpCostService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CloudCostAggregator {
+
+    private static final DateTimeFormatter MONTH_KEY = DateTimeFormatter.ofPattern("yyyyMM");
+
+    private final AwsCostService awsCostService;
+    private final AzureCostService azureCostService;
+    private final GcpCostService gcpCostService;
+    private final NcpCostService ncpCostService;
+    private final CurrencyConversionService currencyConversionService;
+
+    public CloudCostSnapshot calculateCurrentMonth(Long memberId) {
+        LocalDate start = LocalDate.now().withDayOfMonth(1);
+        LocalDate endExclusive = start.plusMonths(1);
+
+        String startDate = start.toString();
+        String endDate = endExclusive.toString();
+        String month = start.format(MONTH_KEY);
+
+        BigDecimal aws = safeAwsSum(memberId, startDate, endDate);
+        BigDecimal azure = safeAzureSum(memberId, startDate, endDate);
+        BigDecimal gcp = safeGcpSum(memberId, startDate, endDate);
+        BigDecimal ncp = safeNcpSum(memberId, month);
+
+        BigDecimal total = aws.add(azure).add(gcp).add(ncp);
+
+        return new CloudCostSnapshot(total, aws, azure, gcp, ncp, month);
+    }
+
+    private BigDecimal safeAwsSum(Long memberId, String startDate, String endDate) {
+        try {
+            List<AwsCostService.AccountCost> costs = awsCostService.getAllAccountsCosts(memberId, startDate, endDate);
+            double sum = costs.stream().mapToDouble(AwsCostService.AccountCost::totalCost).sum();
+            return currencyConversionService.usdToKrw(BigDecimal.valueOf(sum));
+        } catch (Exception e) {
+            log.warn("Failed to aggregate AWS cost for member {}: {}", memberId, e.getMessage());
+            return BigDecimal.ZERO;
+        }
+    }
+
+    private BigDecimal safeAzureSum(Long memberId, String startDate, String endDate) {
+        try {
+            List<AzureCostService.AccountCost> costs = azureCostService.getAllAccountsCosts(memberId, startDate, endDate);
+            BigDecimal total = BigDecimal.ZERO;
+            for (AzureCostService.AccountCost cost : costs) {
+                BigDecimal amount = BigDecimal.valueOf(cost.getAmount()).setScale(2, RoundingMode.HALF_UP);
+                String currency = cost.getCurrency() != null ? cost.getCurrency() : "USD";
+                total = total.add(currencyConversionService.convert(amount, currency, "KRW"));
+            }
+            return total;
+        } catch (Exception e) {
+            log.warn("Failed to aggregate Azure cost for member {}: {}", memberId, e.getMessage());
+            return BigDecimal.ZERO;
+        }
+    }
+
+    private BigDecimal safeGcpSum(Long memberId, String startDate, String endDate) {
+        try {
+            double total = gcpCostService.getMemberTotalNetCost(memberId, startDate, endDate);
+            return currencyConversionService.usdToKrw(BigDecimal.valueOf(total));
+        } catch (Exception e) {
+            log.warn("Failed to aggregate GCP cost for member {}: {}", memberId, e.getMessage());
+            return BigDecimal.ZERO;
+        }
+    }
+
+    private BigDecimal safeNcpSum(Long memberId, String month) {
+        try {
+            double total = ncpCostService.getMemberMonthlyCost(memberId, month);
+            return BigDecimal.valueOf(total).setScale(2, RoundingMode.HALF_UP);
+        } catch (Exception e) {
+            log.warn("Failed to aggregate NCP cost for member {}: {}", memberId, e.getMessage());
+            return BigDecimal.ZERO;
+        }
+    }
+
+    public record CloudCostSnapshot(
+            BigDecimal totalKrw,
+            BigDecimal awsKrw,
+            BigDecimal azureKrw,
+            BigDecimal gcpKrw,
+            BigDecimal ncpKrw,
+            String month
+    ) {
+    }
+}
+

--- a/src/main/java/com/budgetops/backend/budget/service/CloudCostAggregator.java
+++ b/src/main/java/com/budgetops/backend/budget/service/CloudCostAggregator.java
@@ -1,6 +1,7 @@
 package com.budgetops.backend.budget.service;
 
 import com.budgetops.backend.azure.service.AzureCostService;
+import com.budgetops.backend.billing.repository.BillingRepository;
 import com.budgetops.backend.aws.service.AwsCostService;
 import com.budgetops.backend.gcp.service.GcpCostService;
 import com.budgetops.backend.ncp.service.NcpCostService;
@@ -26,6 +27,7 @@ public class CloudCostAggregator {
     private final GcpCostService gcpCostService;
     private final NcpCostService ncpCostService;
     private final CurrencyConversionService currencyConversionService;
+    private final BillingRepository billingRepository;
 
     public CloudCostSnapshot calculateCurrentMonth(Long memberId) {
         LocalDate start = LocalDate.now().withDayOfMonth(1);
@@ -39,10 +41,11 @@ public class CloudCostAggregator {
         BigDecimal azure = safeAzureSum(memberId, startDate, endDate);
         BigDecimal gcp = safeGcpSum(memberId, startDate, endDate);
         BigDecimal ncp = safeNcpSum(memberId, month);
+        BigDecimal billing = safeBillingCost(memberId);
 
-        BigDecimal total = aws.add(azure).add(gcp).add(ncp);
+        BigDecimal total = aws.add(azure).add(gcp).add(ncp).add(billing);
 
-        return new CloudCostSnapshot(total, aws, azure, gcp, ncp, month);
+        return new CloudCostSnapshot(total, aws, azure, gcp, ncp, billing, month);
     }
 
     private BigDecimal safeAwsSum(Long memberId, String startDate, String endDate) {
@@ -92,12 +95,19 @@ public class CloudCostAggregator {
         }
     }
 
+    private BigDecimal safeBillingCost(Long memberId) {
+        return billingRepository.findByMemberId(memberId)
+                .map(billing -> BigDecimal.valueOf(billing.getCurrentPrice()).setScale(2, RoundingMode.HALF_UP))
+                .orElse(BigDecimal.ZERO);
+    }
+
     public record CloudCostSnapshot(
             BigDecimal totalKrw,
             BigDecimal awsKrw,
             BigDecimal azureKrw,
             BigDecimal gcpKrw,
             BigDecimal ncpKrw,
+            BigDecimal billingKrw,
             String month
     ) {
     }

--- a/src/main/java/com/budgetops/backend/budget/service/CurrencyConversionService.java
+++ b/src/main/java/com/budgetops/backend/budget/service/CurrencyConversionService.java
@@ -1,0 +1,36 @@
+package com.budgetops.backend.budget.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+@Service
+public class CurrencyConversionService {
+
+    @Value("${app.currency.usd-to-krw:1350}")
+    private BigDecimal usdToKrwRate;
+
+    public BigDecimal convert(BigDecimal amount, String fromCurrency, String toCurrency) {
+        if (amount == null || fromCurrency == null || toCurrency == null) {
+            return BigDecimal.ZERO;
+        }
+        if (fromCurrency.equalsIgnoreCase(toCurrency)) {
+            return amount;
+        }
+        if (fromCurrency.equalsIgnoreCase("USD") && toCurrency.equalsIgnoreCase("KRW")) {
+            return amount.multiply(usdToKrwRate).setScale(2, RoundingMode.HALF_UP);
+        }
+        if (fromCurrency.equalsIgnoreCase("KRW") && toCurrency.equalsIgnoreCase("USD")) {
+            return amount.divide(usdToKrwRate, 2, RoundingMode.HALF_UP);
+        }
+        // 지원하지 않는 통화 조합이면 입력 값을 그대로 반환
+        return amount;
+    }
+
+    public BigDecimal usdToKrw(BigDecimal amount) {
+        return convert(amount, "USD", "KRW");
+    }
+}
+

--- a/src/main/java/com/budgetops/backend/domain/user/entity/Member.java
+++ b/src/main/java/com/budgetops/backend/domain/user/entity/Member.java
@@ -5,6 +5,7 @@ import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 @Entity
@@ -33,4 +34,13 @@ public class Member {
     @UpdateTimestamp
     @Column(nullable = false)
     private LocalDateTime updatedAt;
+
+    @Column(name = "monthly_budget_limit", precision = 19, scale = 2)
+    private BigDecimal monthlyBudgetLimit;
+
+    @Column(name = "budget_alert_threshold")
+    private Integer budgetAlertThreshold;
+
+    @Column(name = "budget_alert_triggered_at")
+    private LocalDateTime budgetAlertTriggeredAt;
 }

--- a/src/main/java/com/budgetops/backend/gcp/service/GcpCostService.java
+++ b/src/main/java/com/budgetops/backend/gcp/service/GcpCostService.java
@@ -249,6 +249,27 @@ public class GcpCostService {
         
         return response;
     }
+
+    /**
+     * 특정 회원의 모든 GCP 계정 비용 합계
+     */
+    @Transactional(readOnly = true)
+    public double getMemberTotalNetCost(Long memberId, String startDate, String endDate) {
+        List<GcpAccount> accounts = accountRepository.findByOwnerId(memberId);
+        if (accounts.isEmpty()) {
+            return 0.0;
+        }
+        double total = 0.0;
+        for (GcpAccount account : accounts) {
+            try {
+                GcpAccountDailyCostsResponse response = getCosts(account.getId(), startDate, endDate);
+                total += Math.max(0.0, response.getTotalNetCost());
+            } catch (Exception e) {
+                log.warn("Failed to fetch GCP cost for account {}: {}", account.getId(), e.getMessage());
+            }
+        }
+        return roundToFirstDecimal(total);
+    }
     
     /**
      * Billing Export 테이블 이름 목록 찾기

--- a/src/main/java/com/budgetops/backend/ncp/entity/NcpAccount.java
+++ b/src/main/java/com/budgetops/backend/ncp/entity/NcpAccount.java
@@ -1,6 +1,7 @@
 package com.budgetops.backend.ncp.entity;
 
 import com.budgetops.backend.aws.support.CryptoStringConverter;
+import com.budgetops.backend.domain.user.entity.Member;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
@@ -32,4 +33,16 @@ public class NcpAccount {
     private String regionCode; // KR, JP, US 등
 
     private Boolean active = Boolean.TRUE; // 등록 즉시 활성
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member owner;
+
+    @PrePersist
+    @PreUpdate
+    private void ensureOwnerAssigned() {
+        if (owner == null) {
+            throw new IllegalStateException("Owner must be assigned to NCP account before persisting.");
+        }
+    }
 }

--- a/src/main/java/com/budgetops/backend/ncp/repository/NcpAccountRepository.java
+++ b/src/main/java/com/budgetops/backend/ncp/repository/NcpAccountRepository.java
@@ -9,4 +9,7 @@ import java.util.Optional;
 public interface NcpAccountRepository extends JpaRepository<NcpAccount, Long> {
     Optional<NcpAccount> findByAccessKey(String accessKey);
     List<NcpAccount> findByActiveTrue();
+    List<NcpAccount> findByOwnerId(Long ownerId);
+    List<NcpAccount> findByOwnerIdAndActiveTrue(Long ownerId);
+    Optional<NcpAccount> findByIdAndOwnerId(Long id, Long ownerId);
 }

--- a/src/main/java/com/budgetops/backend/ncp/service/NcpAccountService.java
+++ b/src/main/java/com/budgetops/backend/ncp/service/NcpAccountService.java
@@ -1,5 +1,7 @@
 package com.budgetops.backend.ncp.service;
 
+import com.budgetops.backend.domain.user.entity.Member;
+import com.budgetops.backend.domain.user.repository.MemberRepository;
 import com.budgetops.backend.ncp.dto.NcpAccountCreateRequest;
 import com.budgetops.backend.ncp.entity.NcpAccount;
 import com.budgetops.backend.ncp.repository.NcpAccountRepository;
@@ -20,12 +22,13 @@ import static org.springframework.http.HttpStatus.NOT_FOUND;
 public class NcpAccountService {
     private final NcpAccountRepository accountRepo;
     private final NcpCredentialValidator credentialValidator;
+    private final MemberRepository memberRepository;
 
     @Value("${app.ncp.validate:true}")
     private boolean validate;
 
     @Transactional
-    public NcpAccount createWithVerify(NcpAccountCreateRequest req) {
+    public NcpAccount createWithVerify(NcpAccountCreateRequest req, Long memberId) {
         // 입력값 trim
         String accessKey = req.getAccessKey() != null ? req.getAccessKey().trim() : null;
         String secretKey = req.getSecretKey() != null ? req.getSecretKey().trim() : null;
@@ -33,6 +36,7 @@ public class NcpAccountService {
         String regionCode = req.getRegionCode() != null ? req.getRegionCode().trim() : null;
 
         log.info("Creating NCP account with accessKey: {}", accessKey);
+        Member owner = getMember(memberId);
 
         // 기존 계정이 있는지 확인 (활성/비활성 모두 포함)
         var existingAccount = accountRepo.findByAccessKey(accessKey);
@@ -59,6 +63,7 @@ public class NcpAccountService {
             }
 
             // 계정 정보 업데이트
+            account.setOwner(owner);
             account.setName(name);
             account.setRegionCode(regionCode);
             account.setSecretKeyEnc(secretKey); // @Convert에 의해 암호화 저장
@@ -90,6 +95,7 @@ public class NcpAccountService {
         }
 
         NcpAccount a = new NcpAccount();
+        a.setOwner(owner);
         a.setName(name);
         a.setRegionCode(regionCode);
         a.setAccessKey(accessKey);
@@ -103,21 +109,21 @@ public class NcpAccountService {
     }
 
     @Transactional(readOnly = true)
-    public List<NcpAccount> getActiveAccounts() {
-        return accountRepo.findByActiveTrue();
+    public List<NcpAccount> getActiveAccounts(Long memberId) {
+        return accountRepo.findByOwnerIdAndActiveTrue(memberId);
     }
 
     @Transactional(readOnly = true)
-    public NcpAccount getAccountInfo(Long accountId) {
-        return accountRepo.findById(accountId)
+    public NcpAccount getAccountInfo(Long accountId, Long memberId) {
+        return accountRepo.findByIdAndOwnerId(accountId, memberId)
                 .orElseThrow(() -> new ResponseStatusException(NOT_FOUND, "계정을 찾을 수 없습니다."));
     }
 
     @Transactional
-    public void deactivateAccount(Long accountId) {
+    public void deactivateAccount(Long accountId, Long memberId) {
         log.info("Deactivating NCP account with id: {}", accountId);
 
-        NcpAccount account = accountRepo.findById(accountId)
+        NcpAccount account = accountRepo.findByIdAndOwnerId(accountId, memberId)
                 .orElseThrow(() -> {
                     log.error("Account not found with id: {}", accountId);
                     return new ResponseStatusException(NOT_FOUND, "계정을 찾을 수 없습니다.");
@@ -131,5 +137,10 @@ public class NcpAccountService {
         } else {
             log.warn("Account with id: {} is already inactive", accountId);
         }
+    }
+
+    private Member getMember(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("Member를 찾을 수 없습니다: " + memberId));
     }
 }

--- a/src/main/java/com/budgetops/backend/oauth/controller/AuthController.java
+++ b/src/main/java/com/budgetops/backend/oauth/controller/AuthController.java
@@ -31,7 +31,17 @@ public class AuthController {
 
         Claims claims = jwtTokenProvider.getClaims(jwt);
 
+        Long memberId = claims.get("memberId", Long.class);
+        if (memberId == null) {
+            try {
+                memberId = Long.parseLong(claims.getSubject());
+            } catch (NumberFormatException ignored) {
+                memberId = null;
+            }
+        }
+
         UserInfo userInfo = UserInfo.builder()
+                .id(memberId)
                 .email(claims.get("email", String.class))
                 .name(claims.get("name", String.class))
                 .picture(claims.get("picture", String.class))

--- a/src/main/java/com/budgetops/backend/oauth/controller/UserController.java
+++ b/src/main/java/com/budgetops/backend/oauth/controller/UserController.java
@@ -30,7 +30,17 @@ public class UserController {
 
         Claims claims = jwtTokenProvider.getClaims(jwt);
 
+        Long memberId = claims.get("memberId", Long.class);
+        if (memberId == null) {
+            try {
+                memberId = Long.parseLong(claims.getSubject());
+            } catch (NumberFormatException ignored) {
+                memberId = null;
+            }
+        }
+
         UserInfo userInfo = UserInfo.builder()
+                .id(memberId)
                 .email(claims.get("email", String.class))
                 .name(claims.get("name", String.class))
                 .picture(claims.get("picture", String.class))

--- a/src/main/java/com/budgetops/backend/oauth/dto/UserInfo.java
+++ b/src/main/java/com/budgetops/backend/oauth/dto/UserInfo.java
@@ -10,6 +10,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class UserInfo {
+    private Long id;
     private String email;
     private String name;
     private String picture;


### PR DESCRIPTION
**개요**
사용자 예산 설정 및 알림 기능을 구현하고, 대시보드에 예산 정보를 표시할 수 있도록 개선했습니다.

**주요내용**
사용자 예산 설정: 개인별 클라우드 비용 예산 설정 기능 추가
예산 알림 시스템: 설정된 예산 초과 시 알림 발송 기능 구현
대시보드 통합: 예산 사용 현황을 대시보드에 시각적으로 표시
배포 설정 개선: deploy.yml에 feature/21 테스트 배포 트리거 추가
예산 사용량 계산: billing_cost를 예산 사용량에 포함하는 로직 추가
예산 계산 정확도 개선: billing_price를 예산 사용량에서 제외하여 정확한 비용 추적
사용자 정보 응답 개선: member_id를 사용자 정보 API 응답에 포함

**기대효과**
사용자 주도적 비용 관리로 예산 초과 방지 및 비용 절감 유도
실시간 예산 사용 현황 제공으로 클라우드 지출에 대한 가시성 확보
예산 알림 시스템으로 적시 대응 가능 및 예기치 않은 비용 발생 방지
대시보드 통합으로 한눈에 예산 상태 파악 가능
정확한 billing 비용 계산으로 신뢰할 수 있는 예산 관리 제공
비용 인식 개선으로 사용자의 클라우드 리소스 사용 최적화 유도
member_id 제공으로 프론트엔드에서 사용자별 상세 정보 처리 가능

**특이사항**
- 현재 알림은 뜨지 않는 것으로 확인된다. 