### PR TITLE
fix: auto-initialize billing data for users without billing records

### DIFF
--- a/src/main/java/com/budgetops/backend/billing/controller/BillingController.java
+++ b/src/main/java/com/budgetops/backend/billing/controller/BillingController.java
@@ -32,8 +32,13 @@ public class BillingController {
     @GetMapping
     public ResponseEntity<BillingResponse> getBilling(@PathVariable Long userId) {
         Member member = getMemberById(userId);
+
+        // Billing 데이터가 없으면 자동으로 초기화
         Billing billing = billingService.getBillingByMember(member)
-                .orElseThrow(BillingNotFoundException::new);
+                .orElseGet(() -> {
+                    log.warn("Billing not found for user {}, initializing...", userId);
+                    return billingService.initializeBilling(member);
+                });
 
         log.info("요금제 조회: userId={}, plan={}", userId, billing.getCurrentPlan());
         return ResponseEntity.ok(BillingResponse.from(billing));
@@ -48,6 +53,14 @@ public class BillingController {
             @PathVariable String planName
     ) {
         Member member = getMemberById(userId);
+
+        // Billing 데이터가 없으면 먼저 초기화
+        billingService.getBillingByMember(member)
+                .orElseGet(() -> {
+                    log.warn("Billing not found for user {}, initializing before plan change...", userId);
+                    return billingService.initializeBilling(member);
+                });
+
         Billing billing = billingService.changePlan(member, planName);
 
         log.info("요금제 변경 완료: userId={}, newPlan={}, price={}",


### PR DESCRIPTION
## Bug Fix: Billing 데이터 자동 초기화 기능 추가

  ### 문제 상황
  - 사용자 ID 8과 같이 `member` 테이블에는 존재하지만 `billing` 테이블에
  데이터가 없는 경우 발생
  - 플랜 변경 시도 시 `BillingNotFoundException` 발생 → 404 에러
  - DB 마이그레이션 또는 재구축 과정에서 기존 회원의 billing 데이터가 누락된
  경우 발생

  ### 로그 분석 결과
  2025-11-26T06:10:40.784Z ERROR 1 --- [budgetops-backend] [nio-8080-exec-9]
  c.b.b.b.e.GlobalExceptionHandler : BillingNotFoundException:
  해당 사용자의 요금제 정보를 찾을 수 없습니다: 8

  ### 해결 방법
  Billing 데이터가 없는 사용자에 대해 **자동으로 FREE 플랜으로 초기화**하도록
   수정

  #### 변경 사항
  - **요금제 조회 API** (`GET /api/v1/users/{userId}/billing`)
    - `BillingNotFoundException` 발생 대신 → FREE 플랜으로 자동 초기화

  - **요금제 변경 API** (`PUT
  /api/v1/users/{userId}/billing/plan/{planName}`)
    - Billing 데이터 없을 시 → FREE 플랜으로 먼저 초기화 후 플랜 변경 진행

  ### 기대 효과
  - DB 마이그레이션 후에도 기존 사용자가 서비스 정상 이용 가능
  - Billing 데이터 누락으로 인한 404 에러 방지
  - 회원가입 프로세스에서 billing 초기화 누락되어도 자동 복구

