### PR TITLE
fix: 토큰 시스템 할당량 및 구매 제한 로직 개선

### DIFF
--- a/src/main/java/com/budgetops/backend/billing/constants/TokenConstants.java
+++ b/src/main/java/com/budgetops/backend/billing/constants/TokenConstants.java
@@ -1,0 +1,21 @@
+package com.budgetops.backend.billing.constants;
+
+/**
+ * 토큰 관련 상수
+ */
+public class TokenConstants {
+
+    /**
+     * Pro 플랜의 최대 토큰 보유량
+     */
+    public static final int MAX_TOKEN_LIMIT = 100000;
+
+    /**
+     * Free 플랜의 최대 토큰 보유량
+     */
+    public static final int FREE_PLAN_MAX_TOKENS = 10000;
+
+    private TokenConstants() {
+        // 유틸리티 클래스, 인스턴스화 방지
+    }
+}

--- a/src/main/java/com/budgetops/backend/billing/enums/BillingPlan.java
+++ b/src/main/java/com/budgetops/backend/billing/enums/BillingPlan.java
@@ -4,12 +4,12 @@ import lombok.Getter;
 
 @Getter
 public enum BillingPlan {
-    FREE("Free", 0, 100),      // AI 어시스턴트 기본 할당량
-    PRO("Pro", 4900, 1000);    // AI 어시스턴트 확장 할당량
+    FREE("Free", 0, 10000),      // AI 어시스턴트 기본 할당량 (10k 토큰)
+    PRO("Pro", 4900, 30000);     // AI 어시스턴트 확장 할당량 (30k 토큰 = 기본 10k + Pro 추가 20k)
 
     private final String displayName;
     private final int monthlyPrice;        // 월 고정 가격 (원화 KRW)
-    private final int aiAssistantQuota;    // AI 어시스턴트 월 사용 할당량
+    private final int aiAssistantQuota;    // AI 어시스턴트 월 사용 할당량 (토큰)
 
     BillingPlan(String displayName, int monthlyPrice, int aiAssistantQuota) {
         this.displayName = displayName;

--- a/src/main/java/com/budgetops/backend/billing/enums/TokenPackage.java
+++ b/src/main/java/com/budgetops/backend/billing/enums/TokenPackage.java
@@ -8,9 +8,9 @@ import lombok.Getter;
  */
 @Getter
 public enum TokenPackage {
-    SMALL("small", 100, 5000, 0, false),
-    MEDIUM("medium", 500, 20000, 50, true),
-    LARGE("large", 1000, 35000, 150, false);
+    SMALL("small", 10000, 5000, 0, false),
+    MEDIUM("medium", 30000, 12000, 0, true),
+    LARGE("large", 50000, 18000, 0, false);
 
     private final String id;
     private final int tokenAmount;

--- a/src/main/java/com/budgetops/backend/billing/service/BillingService.java
+++ b/src/main/java/com/budgetops/backend/billing/service/BillingService.java
@@ -31,11 +31,13 @@ public class BillingService {
                 .member(member)
                 .currentPlan(BillingPlan.FREE)
                 .currentPrice(0)
+                .currentTokens(BillingPlan.FREE.getAiAssistantQuota())  // Free 플랜 초기 토큰 (10k)
                 .build();
 
         billing.setNextBillingDateFromNow();
 
-        log.info("빌링 초기화: memberId={}, plan=FREE", member.getId());
+        log.info("빌링 초기화: memberId={}, plan=FREE, initialTokens={}",
+                member.getId(), BillingPlan.FREE.getAiAssistantQuota());
         return billingRepository.save(billing);
     }
 
@@ -92,6 +94,22 @@ public class BillingService {
 
         // 요금제 변경
         billing.changePlan(newPlan);
+
+        // 플랜에 따라 토큰 조정
+        int currentTokens = billing.getCurrentTokens();
+        int planQuota = newPlan.getAiAssistantQuota();
+
+        // 현재 토큰이 새 플랜의 기본 할당량보다 적으면 기본 할당량으로 설정
+        // (처음 가입 or 플랜 업그레이드 시 최소 보장)
+        if (currentTokens < planQuota) {
+            billing.setCurrentTokens(planQuota);
+            log.info("플랜 변경에 따른 토큰 증가: memberId={}, oldPlan={}, newPlan={}, oldTokens={}, newTokens={}",
+                    member.getId(), currentPlan, newPlan, currentTokens, planQuota);
+        } else {
+            // 기존 토큰 유지 (사용자가 구매한 토큰 보호)
+            log.info("플랜 변경, 기존 토큰 유지: memberId={}, oldPlan={}, newPlan={}, tokens={}",
+                    member.getId(), currentPlan, newPlan, currentTokens);
+        }
 
         // 다음 결제일 업데이트 (유료 플랜인 경우에만)
         if (!newPlan.isFree()) {


### PR DESCRIPTION
- BillingPlan: Free 10k, Pro 30k 토큰 할당
- TokenPackage: 구매 패키지 금액 조정 (10k/30k/50k)
- TokenConstants: 최대 보유량 상수 정의 (100k)
- PaymentController: Pro 플랜 토큰 구매 제한 로직 추가
- BillingService: 플랜 변경 시 토큰 보호 로직 구현
  - 가입 시 Free 플랜 10k 자동 할당
  - 플랜 변경 시 기존 토큰 유지 및 최소값 보장