### PR TITLE
fix: Pro 플랜 최대 토큰 보유량을 100k로 수정

### DIFF
--- a/src/main/java/com/budgetops/backend/billing/dto/response/BillingResponse.java
+++ b/src/main/java/com/budgetops/backend/billing/dto/response/BillingResponse.java
@@ -1,6 +1,7 @@
 package com.budgetops.backend.billing.dto.response;
 
 import com.budgetops.backend.billing.constants.DateConstants;
+import com.budgetops.backend.billing.constants.TokenConstants;
 import com.budgetops.backend.billing.entity.Billing;
 import com.budgetops.backend.billing.enums.BillingPlan;
 import lombok.AllArgsConstructor;
@@ -60,7 +61,7 @@ public class BillingResponse {
 
                 // 토큰/할당량 정보
                 .currentTokens(billing.getCurrentTokens())
-                .maxTokens(plan.getAiAssistantQuota())
+                .maxTokens(plan.isFree() ? TokenConstants.FREE_PLAN_MAX_TOKENS : TokenConstants.MAX_TOKEN_LIMIT)
                 .tokenResetDate(billing.getNextBillingDate() != null
                     ? billing.getNextBillingDate().format(DateConstants.DATE_FORMAT)
                     : null)


### PR DESCRIPTION
- BillingResponse maxTokens 필드 수정
- Free 플랜: 10k 유지
- Pro 플랜: 30k -> 100k (최대 보유량 반영)