### PR TITLE
Fix/ Member password 필드를 nullable로 변경 (OAuth 사용자 지원)

### DIFF
--- a/src/main/java/com/budgetops/backend/billing/entity/Member.java
+++ b/src/main/java/com/budgetops/backend/billing/entity/Member.java
@@ -29,7 +29,7 @@ public class Member {
     @Column(nullable = false)
     private String name;
 
-    @Column(nullable = false)
+    @Column
     private String password;
 
     @ManyToMany(mappedBy = "members")


### PR DESCRIPTION
### 작업 개요
OAuth 기반 로그인 사용자를 지원하기 위해 Member 엔티티의 password 필드를 nullable로 변경했습니다. 비밀번호를 사용하지 않는 OAuth 회원도 정상적으로 가입·로그인이 가능하도록 스키마를 조정했습니다.

### 변경 사항

* Member 엔티티의 password 컬럼 옵션을 NOT NULL → NULL 허용으로 변경
* 비밀번호가 없는(OAuth) 회원 레코드도 생성 가능하도록 제약 조건 완화

### 영향 및 고려 사항

* 기존 ID/PW 로그인 사용자는 기존 로직 그대로 동작 (비밀번호 필수)
* OAuth 사용자에 대해서는 비밀번호 없이도 회원 정보가 저장될 수 있음
* 애플리케이션 레벨에서 비밀번호 기반 로그인 시 `password IS NULL` 사용자에 대한 분기 처리가 필요함 (OAuth 전용 계정)