### PR TITLE
feat: AI 챗봇 토큰 소비 로직 구현

### DIFF
--- a/src/main/java/com/budgetops/backend/ai/dto/ChatResponse.java
+++ b/src/main/java/com/budgetops/backend/ai/dto/ChatResponse.java
@@ -12,5 +12,17 @@ import lombok.NoArgsConstructor;
 public class ChatResponse {
     private String response;
     private String sessionId;
+    private TokenUsage tokenUsage;
+    private Integer remainingTokens;
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class TokenUsage {
+        private Integer promptTokens;      // 입력 토큰
+        private Integer completionTokens;  // 출력 토큰
+        private Integer totalTokens;       // 총 토큰
+    }
 }
 

--- a/src/main/java/com/budgetops/backend/billing/entity/Billing.java
+++ b/src/main/java/com/budgetops/backend/billing/entity/Billing.java
@@ -66,6 +66,23 @@ public class Billing {
     }
 
     /**
+     * 토큰 차감
+     */
+    public void consumeTokens(int tokens) {
+        if (this.currentTokens < tokens) {
+            throw new IllegalStateException("토큰이 부족합니다. 현재: " + this.currentTokens + ", 필요: " + tokens);
+        }
+        this.currentTokens -= tokens;
+    }
+
+    /**
+     * 토큰 보유 여부 확인
+     */
+    public boolean hasEnoughTokens(int required) {
+        return this.currentTokens >= required;
+    }
+
+    /**
      * 무료 요금제인지 확인
      */
     public boolean isFreePlan() {


### PR DESCRIPTION
- Gemini API 응답에서 usageMetadata 파싱 추가
- ChatResponse에 tokenUsage 및 remainingTokens 필드 추가
- Billing 엔티티에 토큰 차감 메서드 추가 (consumeTokens, hasEnoughTokens)
- BillingService에 토큰 소비 관련 메서드 구현
- AIChatService에서 AI 응답 후 자동 토큰 차감
- 토큰 부족 시 예외 처리 추가