### PR TITLE
feat: 결제 내역 조회 기능 개선

### DIFF
--- a/src/main/java/com/budgetops/backend/billing/repository/PaymentHistoryRepository.java
+++ b/src/main/java/com/budgetops/backend/billing/repository/PaymentHistoryRepository.java
@@ -3,6 +3,8 @@ package com.budgetops.backend.billing.repository;
 import com.budgetops.backend.billing.entity.PaymentHistory;
 import com.budgetops.backend.domain.user.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -29,4 +31,10 @@ public interface PaymentHistoryRepository extends JpaRepository<PaymentHistory, 
      * merchantUid로 결제 내역 조회
      */
     PaymentHistory findByMerchantUid(String merchantUid);
+
+    /**
+     * 사용자 이름 또는 이메일로 결제 내역 검색
+     */
+    @Query("SELECT ph FROM PaymentHistory ph JOIN ph.member m WHERE m.name LIKE %:search% OR m.email LIKE %:search%")
+    List<PaymentHistory> findByMemberNameOrEmailContaining(@Param("search") String search);
 }


### PR DESCRIPTION
#124

- AdminService에서 Payment와 PaymentHistory를 통합하여 전체 사용자의 결제 내역을 조회하는 로직 추가
- PaymentHistoryRepository에 사용자 이름 또는 이메일로 결제 내역을 검색하는 쿼리 메서드 추가
- 결제 내역 응답 형식을 AdminPaymentHistoryResponse로 통일하고, 최신순으로 정렬하여 반환