### PR TITLE
Feature/31 GCP 리소스 기반 절감 액션 추천 기능 추가

### DIFF
--- a/src/main/java/com/budgetops/backend/simulator/service/RecommendationService.java
+++ b/src/main/java/com/budgetops/backend/simulator/service/RecommendationService.java
@@ -238,12 +238,10 @@ public class RecommendationService {
             }
         }
         
-        // GCP 리소스 조회
-        List<GcpAccount> activeGcpAccounts = gcpAccountRepository.findAll().stream()
-                .filter(account -> Boolean.TRUE.equals(account.getActive()))
-                .collect(Collectors.toList());
+        // GCP 리소스 조회 (GCP 계정에는 active 필드가 없으므로 모든 계정 조회)
+        List<GcpAccount> gcpAccounts = gcpAccountRepository.findAll();
         
-        for (GcpAccount account : activeGcpAccounts) {
+        for (GcpAccount account : gcpAccounts) {
             try {
                 GcpResourceListResponse response = gcpResourceService.listResources(account.getId(), account.getOwner().getId());
                 
@@ -370,12 +368,10 @@ public class RecommendationService {
                 }
             }
             
-            // GCP 리소스에서 찾기
-            List<GcpAccount> activeGcpAccounts = gcpAccountRepository.findAll().stream()
-                    .filter(account -> Boolean.TRUE.equals(account.getActive()))
-                    .collect(Collectors.toList());
+            // GCP 리소스에서 찾기 (GCP 계정에는 active 필드가 없으므로 모든 계정 조회)
+            List<GcpAccount> gcpAccounts = gcpAccountRepository.findAll();
             
-            for (GcpAccount account : activeGcpAccounts) {
+            for (GcpAccount account : gcpAccounts) {
                 try {
                     GcpResourceListResponse response = gcpResourceService.listResources(account.getId(), account.getOwner().getId());
                     


### PR DESCRIPTION
### 작업 개요
GCP Compute Engine 인스턴스를 비용 절감 시뮬레이션 대상으로 확장하고, 절감 액션 추천 시 GCP 리소스 정보를 함께 활용하도록 RecommendationService를 개선했습니다.

### 변경 사항
* RecommendationService에 GCP 리소스 조회 로직 추가
* getAllResourceIds()에서 AWS EC2 + GCP Compute 리소스 통합 조회
* 절감 액션 근거 생성 시 GCP 리소스 메타데이터 포함
* GCP Compute Engine 인스턴스를 비용 절감 시뮬레이션 대상에 포함

### 영향 범위
* 절감 액션 추천 API에서 AWS 리소스뿐 아니라 GCP 리소스에 대한 추천도 함께 노출됩니다.
* 기존 AWS 기반 동작에는 변화가 없으며, GCP 연결 환경에서만 확장된 추천이 적용됩니다.
