### PR TITLE
Feature/34 AwsAccountService 테스트 코드 추가

### DIFF
--- a/src/test/java/com/AwsAccountServiceTest.java
+++ b/src/test/java/com/AwsAccountServiceTest.java
@@ -1,0 +1,275 @@
+package com.budgetops.backend.aws.service;
+
+import com.budgetops.backend.aws.dto.AwsAccountCreateRequest;
+import com.budgetops.backend.aws.entity.AwsAccount;
+import com.budgetops.backend.aws.repository.AwsAccountRepository;
+import com.budgetops.backend.aws.repository.AwsResourceRepository;
+import com.budgetops.backend.domain.user.entity.Member;
+import com.budgetops.backend.domain.user.repository.MemberRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AwsAccount Service 테스트")
+class AwsAccountServiceTest {
+
+    @Mock
+    private AwsAccountRepository accountRepo;
+
+    @Mock
+    private AwsCredentialValidator credentialValidator;
+
+    @Mock
+    private AwsResourceRepository resourceRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @InjectMocks
+    private AwsAccountService awsAccountService;
+
+    private Member testMember;
+    private AwsAccount testAccount;
+    private AwsAccountCreateRequest createRequest;
+
+    @BeforeEach
+    void setUp() {
+        // validate 플래그를 false로 설정 (테스트에서는 실제 AWS 검증 skip)
+        ReflectionTestUtils.setField(awsAccountService, "validate", false);
+
+        testMember = new Member();
+        testMember.setId(1L);
+        testMember.setEmail("test@example.com");
+        testMember.setName("테스트 사용자");
+
+        testAccount = new AwsAccount();
+        testAccount.setId(100L);
+        testAccount.setOwner(testMember);
+        testAccount.setName("Test AWS Account");
+        testAccount.setAccessKeyId("AKIAIOSFODNN7EXAMPLE");
+        testAccount.setSecretKeyEnc("wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY");
+        testAccount.setSecretKeyLast4("EKEY");
+        testAccount.setDefaultRegion("ap-northeast-2");
+        testAccount.setActive(Boolean.TRUE);
+
+        createRequest = new AwsAccountCreateRequest();
+        createRequest.setName("New AWS Account");
+        createRequest.setAccessKeyId("AKIAIOSFODNN7NEWKEY");
+        createRequest.setSecretAccessKey("newSecretAccessKeyExample123456789");
+        createRequest.setDefaultRegion("us-east-1");
+    }
+
+    @Test
+    @DisplayName("createWithVerify - 새 계정 생성 성공")
+    void createWithVerify_NewAccount_Success() {
+        // given
+        given(memberRepository.findById(1L)).willReturn(Optional.of(testMember));
+        given(accountRepo.findByAccessKeyId(anyString())).willReturn(Optional.empty());
+        given(accountRepo.save(any(AwsAccount.class))).willAnswer(invocation -> {
+            AwsAccount account = invocation.getArgument(0);
+            account.setId(101L);
+            return account;
+        });
+
+        // when
+        AwsAccount result = awsAccountService.createWithVerify(createRequest, 1L);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isEqualTo(101L);
+        assertThat(result.getName()).isEqualTo("New AWS Account");
+        assertThat(result.getActive()).isTrue();
+        verify(accountRepo).save(any(AwsAccount.class));
+    }
+
+    @Test
+    @DisplayName("createWithVerify - 기존 계정 재활성화")
+    void createWithVerify_ExistingAccount_Reactivate() {
+        // given
+        testAccount.setActive(Boolean.FALSE);
+        given(memberRepository.findById(1L)).willReturn(Optional.of(testMember));
+        given(accountRepo.findByAccessKeyId(createRequest.getAccessKeyId()))
+                .willReturn(Optional.of(testAccount));
+        given(accountRepo.save(any(AwsAccount.class))).willReturn(testAccount);
+
+        // when
+        AwsAccount result = awsAccountService.createWithVerify(createRequest, 1L);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getActive()).isTrue();
+        assertThat(result.getName()).isEqualTo("New AWS Account");
+        verify(accountRepo).save(testAccount);
+    }
+
+    @Test
+    @DisplayName("createWithVerify - 다른 회원의 계정 재할당")
+    void createWithVerify_ReassignToNewMember() {
+        // given
+        Member otherMember = new Member();
+        otherMember.setId(2L);
+        otherMember.setEmail("other@example.com");
+        testAccount.setOwner(otherMember);
+
+        given(memberRepository.findById(1L)).willReturn(Optional.of(testMember));
+        given(accountRepo.findByAccessKeyId(createRequest.getAccessKeyId()))
+                .willReturn(Optional.of(testAccount));
+        given(accountRepo.save(any(AwsAccount.class))).willReturn(testAccount);
+
+        // when
+        AwsAccount result = awsAccountService.createWithVerify(createRequest, 1L);
+
+        // then
+        assertThat(result.getOwner().getId()).isEqualTo(1L);
+        verify(accountRepo).save(testAccount);
+    }
+
+    @Test
+    @DisplayName("createWithVerify - 존재하지 않는 회원")
+    void createWithVerify_MemberNotFound() {
+        // given
+        given(memberRepository.findById(999L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> awsAccountService.createWithVerify(createRequest, 999L))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Member를 찾을 수 없습니다");
+    }
+
+    @Test
+    @DisplayName("createWithVerify - 자격증명 검증 활성화 시 유효하지 않은 자격증명")
+    void createWithVerify_InvalidCredentials() {
+        // given
+        ReflectionTestUtils.setField(awsAccountService, "validate", true);
+        given(memberRepository.findById(1L)).willReturn(Optional.of(testMember));
+        given(accountRepo.findByAccessKeyId(anyString())).willReturn(Optional.empty());
+        given(credentialValidator.isValid(anyString(), anyString(), anyString())).willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> awsAccountService.createWithVerify(createRequest, 1L))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("AWS 자격증명이 유효하지 않습니다");
+    }
+
+    @Test
+    @DisplayName("getActiveAccounts - 활성 계정 목록 조회")
+    void getActiveAccounts_Success() {
+        // given
+        given(memberRepository.findById(1L)).willReturn(Optional.of(testMember));
+        given(accountRepo.findByOwnerIdAndActiveTrue(1L)).willReturn(List.of(testAccount));
+
+        // when
+        List<AwsAccount> accounts = awsAccountService.getActiveAccounts(1L);
+
+        // then
+        assertThat(accounts).hasSize(1);
+        assertThat(accounts.get(0).getActive()).isTrue();
+        verify(accountRepo).findByOwnerIdAndActiveTrue(1L);
+    }
+
+    @Test
+    @DisplayName("getActiveAccounts - 활성 계정이 없는 경우")
+    void getActiveAccounts_Empty() {
+        // given
+        given(memberRepository.findById(1L)).willReturn(Optional.of(testMember));
+        given(accountRepo.findByOwnerIdAndActiveTrue(1L)).willReturn(Collections.emptyList());
+
+        // when
+        List<AwsAccount> accounts = awsAccountService.getActiveAccounts(1L);
+
+        // then
+        assertThat(accounts).isEmpty();
+    }
+
+    @Test
+    @DisplayName("getAccountInfo - 계정 정보 조회 성공")
+    void getAccountInfo_Success() {
+        // given
+        given(accountRepo.findByIdAndOwnerId(100L, 1L)).willReturn(Optional.of(testAccount));
+
+        // when
+        AwsAccount account = awsAccountService.getAccountInfo(100L, 1L);
+
+        // then
+        assertThat(account).isNotNull();
+        assertThat(account.getId()).isEqualTo(100L);
+        assertThat(account.getName()).isEqualTo("Test AWS Account");
+    }
+
+    @Test
+    @DisplayName("getAccountInfo - 계정을 찾을 수 없음")
+    void getAccountInfo_NotFound() {
+        // given
+        given(accountRepo.findByIdAndOwnerId(999L, 1L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> awsAccountService.getAccountInfo(999L, 1L))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("계정을 찾을 수 없습니다");
+    }
+
+    @Test
+    @DisplayName("deactivateAccount - 계정 비활성화 성공")
+    void deactivateAccount_Success() {
+        // given
+        given(accountRepo.findByIdAndOwnerId(100L, 1L)).willReturn(Optional.of(testAccount));
+        given(resourceRepository.findByAwsAccountId(100L)).willReturn(Collections.emptyList());
+
+        // when
+        awsAccountService.deactivateAccount(100L, 1L);
+
+        // then
+        verify(accountRepo).delete(testAccount);
+        verify(resourceRepository).findByAwsAccountId(100L);
+    }
+
+    @Test
+    @DisplayName("deactivateAccount - 연결된 리소스도 함께 삭제")
+    void deactivateAccount_WithResources() {
+        // given
+        com.budgetops.backend.aws.entity.AwsResource mockResource = new com.budgetops.backend.aws.entity.AwsResource();
+        mockResource.setId(1L);
+        
+        given(accountRepo.findByIdAndOwnerId(100L, 1L)).willReturn(Optional.of(testAccount));
+        given(resourceRepository.findByAwsAccountId(100L)).willReturn(List.of(mockResource));
+
+        // when
+        awsAccountService.deactivateAccount(100L, 1L);
+
+        // then
+        verify(resourceRepository).deleteAll(anyList());
+        verify(accountRepo).delete(testAccount);
+    }
+
+    @Test
+    @DisplayName("deactivateAccount - 계정을 찾을 수 없음")
+    void deactivateAccount_NotFound() {
+        // given
+        given(accountRepo.findByIdAndOwnerId(999L, 1L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> awsAccountService.deactivateAccount(999L, 1L))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("계정을 찾을 수 없습니다");
+    }
+}
+


### PR DESCRIPTION
제목  
test: AwsAccountService 테스트 코드 추가 (#138)

## 작업 개요
AwsAccountService의 계정 생성, 비활성화, 재활성화, 조회 및 자격 증명 검증 흐름 전반에 대한 단위 테스트를 추가하여, AWS 계정 연동 관련 핵심 비즈니스 로직의 안정성을 검증했습니다.

## 변경 사항
- `AwsAccountServiceTest` 테스트 클래스 추가
- 다음 시나리오를 포함한 총 12개 테스트 케이스 작성

### 계정 생성/재활성화 관련
- 새 계정 생성 성공
- 기존 계정 재활성화 처리
- 다른 회원에게 계정 재할당 처리

### 예외 및 검증 로직
- 존재하지 않는 회원인 경우 예외 처리
- 자격증명(크리덴셜) 검증 실패 시 예외 처리

### 계정 조회 및 목록
- 활성 계정 목록 조회 성공
- 활성 계정이 없는 경우 빈 결과/예외 처리 검증
- 단일 계정 정보 조회 성공
- 계정을 찾을 수 없는 경우 예외 처리

### 계정 비활성화 및 연관 리소스 처리
- 계정 비활성화 성공
- 계정 비활성화 시 연결된 리소스도 함께 삭제되는지 검증
- 이미 삭제되었거나 찾을 수 없는 계정 비활성화 시 NotFound 예외 처리

## 영향 범위
- AwsAccountService 관련 로직 변경 시 회귀를 조기에 감지할 수 있는 테스트 안전망이 강화됩니다.
- 프로덕션 코드 동작에는 변경이 없으며, 테스트 코드 추가에만 해당합니다.
- CI 환경에서 테스트 실행 시간이 소폭 증가할 수 있으나, 허용 가능한 수준입니다.
