### PR TITLE
Feature/37 Alert 관련 (AwsAlertService · GcpAlertService · NcpAlertService · AzureAlertService) 테스트 코드 추가

### DIFF
--- a/src/test/java/com/AwsAlertServiceTest.java
+++ b/src/test/java/com/AwsAlertServiceTest.java
@@ -1,0 +1,100 @@
+package com.budgetops.backend.aws.service;
+
+import com.budgetops.backend.aws.dto.AwsEc2Alert;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AwsAlert Service 테스트")
+class AwsAlertServiceTest {
+
+    @Mock
+    private AwsEc2AlertService ec2AlertService;
+
+    @InjectMocks
+    private AwsAlertService awsAlertService;
+
+    @BeforeEach
+    void setUp() {
+    }
+
+    @Test
+    @DisplayName("checkAllServices - 모든 서비스 알림 체크 성공")
+    void checkAllServices_Success() {
+        // given
+        AwsEc2Alert mockAlert = AwsEc2Alert.builder()
+                .accountId(1L)
+                .instanceId("i-123456")
+                .message("Test alert")
+                .build();
+        
+        given(ec2AlertService.checkAllAccounts()).willReturn(List.of(mockAlert));
+
+        // when
+        List<AwsEc2Alert> alerts = awsAlertService.checkAllServices();
+
+        // then
+        assertThat(alerts).hasSize(1);
+        verify(ec2AlertService).checkAllAccounts();
+    }
+
+    @Test
+    @DisplayName("checkAllServices - EC2 서비스 체크 실패 시에도 계속 진행")
+    void checkAllServices_EC2ServiceFails() {
+        // given
+        given(ec2AlertService.checkAllAccounts()).willThrow(new RuntimeException("EC2 체크 실패"));
+
+        // when
+        List<AwsEc2Alert> alerts = awsAlertService.checkAllServices();
+
+        // then
+        assertThat(alerts).isEmpty();
+    }
+
+    @Test
+    @DisplayName("checkAllServicesForAccount - 특정 계정의 모든 서비스 알림 체크")
+    void checkAllServicesForAccount_Success() {
+        // given
+        AwsEc2Alert mockAlert = AwsEc2Alert.builder()
+                .accountId(100L)
+                .instanceId("i-123456")
+                .message("Test alert")
+                .build();
+        
+        given(ec2AlertService.checkAccount(100L)).willReturn(List.of(mockAlert));
+
+        // when
+        List<AwsEc2Alert> alerts = awsAlertService.checkAllServicesForAccount(100L);
+
+        // then
+        assertThat(alerts).hasSize(1);
+        assertThat(alerts.get(0).getAccountId()).isEqualTo(100L);
+        verify(ec2AlertService).checkAccount(100L);
+    }
+
+    @Test
+    @DisplayName("checkAllServicesForAccount - 알림이 없는 경우")
+    void checkAllServicesForAccount_NoAlerts() {
+        // given
+        given(ec2AlertService.checkAccount(100L)).willReturn(Collections.emptyList());
+
+        // when
+        List<AwsEc2Alert> alerts = awsAlertService.checkAllServicesForAccount(100L);
+
+        // then
+        assertThat(alerts).isEmpty();
+    }
+}
+

--- a/src/test/java/com/AzureAlertServiceTest.java
+++ b/src/test/java/com/AzureAlertServiceTest.java
@@ -1,0 +1,116 @@
+package com.budgetops.backend.azure.service;
+
+import com.budgetops.backend.azure.dto.AzureAlert;
+import com.budgetops.backend.azure.entity.AzureAccount;
+import com.budgetops.backend.azure.repository.AzureAccountRepository;
+import com.budgetops.backend.domain.user.entity.Member;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AzureAlert Service 테스트")
+class AzureAlertServiceTest {
+
+    @Mock
+    private AzureAccountRepository accountRepository;
+
+    @Mock
+    private AzureComputeService computeService;
+
+    @Mock
+    private AzureRuleLoader ruleLoader;
+
+    @InjectMocks
+    private AzureAlertService azureAlertService;
+
+    private AzureAccount testAccount;
+    private Member testMember;
+
+    @BeforeEach
+    void setUp() {
+        testMember = new Member();
+        testMember.setId(1L);
+
+        testAccount = new AzureAccount();
+        testAccount.setId(100L);
+        testAccount.setOwner(testMember);
+        testAccount.setName("Test Azure Account");
+        testAccount.setSubscriptionId("sub-12345");
+        testAccount.setActive(Boolean.TRUE);
+    }
+
+    @Test
+    @DisplayName("checkAllAccounts - 모든 계정 체크")
+    void checkAllAccounts_Success() {
+        // given
+        given(accountRepository.findAll()).willReturn(List.of(testAccount));
+        given(accountRepository.findById(100L)).willReturn(Optional.of(testAccount));
+        given(computeService.listVirtualMachines(anyLong(), anyString())).willReturn(Collections.emptyList());
+        given(ruleLoader.getAllRules()).willReturn(Collections.emptyList());
+
+        // when
+        List<AzureAlert> alerts = azureAlertService.checkAllAccounts();
+
+        // then
+        assertThat(alerts).isNotNull();
+        verify(accountRepository).findAll();
+    }
+
+    @Test
+    @DisplayName("checkAccount - 존재하지 않는 계정")
+    void checkAccount_AccountNotFound() {
+        // given
+        given(accountRepository.findById(999L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> azureAlertService.checkAccount(999L))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Azure 계정을 찾을 수 없습니다");
+    }
+
+    @Test
+    @DisplayName("checkAccount - 비활성화된 계정")
+    void checkAccount_InactiveAccount() {
+        // given
+        testAccount.setActive(Boolean.FALSE);
+        given(accountRepository.findById(100L)).willReturn(Optional.of(testAccount));
+
+        // when
+        List<AzureAlert> alerts = azureAlertService.checkAccount(100L);
+
+        // then
+        assertThat(alerts).isEmpty();
+    }
+
+    @Test
+    @DisplayName("checkAccount - VM 조회 실패 시 빈 리스트 반환")
+    void checkAccount_VmFetchFails() {
+        // given
+        given(accountRepository.findById(100L)).willReturn(Optional.of(testAccount));
+        given(computeService.listVirtualMachines(anyLong(), anyString())).willThrow(new RuntimeException("API 오류"));
+        given(ruleLoader.getAllRules()).willReturn(Collections.emptyList());
+
+        // when
+        List<AzureAlert> alerts = azureAlertService.checkAccount(100L);
+
+        // then
+        assertThat(alerts).isEmpty();
+    }
+}
+

--- a/src/test/java/com/GcpAlertServiceTest.java
+++ b/src/test/java/com/GcpAlertServiceTest.java
@@ -1,0 +1,105 @@
+package com.budgetops.backend.gcp.service;
+
+import com.budgetops.backend.aws.dto.AlertRule;
+import com.budgetops.backend.domain.user.entity.Member;
+import com.budgetops.backend.gcp.dto.GcpAlert;
+import com.budgetops.backend.gcp.dto.GcpResourceListResponse;
+import com.budgetops.backend.gcp.entity.GcpAccount;
+import com.budgetops.backend.gcp.repository.GcpAccountRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GcpAlert Service 테스트")
+class GcpAlertServiceTest {
+
+    @Mock
+    private GcpAccountRepository accountRepository;
+
+    @Mock
+    private GcpResourceService resourceService;
+
+    @Mock
+    private GcpRuleLoader ruleLoader;
+
+    @InjectMocks
+    private GcpAlertService gcpAlertService;
+
+    private GcpAccount testAccount;
+    private Member testMember;
+
+    @BeforeEach
+    void setUp() {
+        testMember = new Member();
+        testMember.setId(1L);
+
+        testAccount = new GcpAccount();
+        testAccount.setId(100L);
+        testAccount.setOwner(testMember);
+        testAccount.setName("Test GCP Account");
+        testAccount.setProjectId("test-project");
+    }
+
+    @Test
+    @DisplayName("checkAllAccounts - 모든 계정 체크")
+    void checkAllAccounts_Success() {
+        // given
+        given(accountRepository.findAll()).willReturn(List.of(testAccount));
+        given(accountRepository.findById(100L)).willReturn(Optional.of(testAccount));
+        given(ruleLoader.getAllRules()).willReturn(Collections.emptyList());
+        
+        GcpResourceListResponse response = new GcpResourceListResponse();
+        response.setResources(Collections.emptyList());
+        given(resourceService.listResources(anyLong(), anyLong())).willReturn(response);
+
+        // when
+        List<GcpAlert> alerts = gcpAlertService.checkAllAccounts();
+
+        // then
+        assertThat(alerts).isNotNull();
+        verify(accountRepository).findAll();
+    }
+
+    @Test
+    @DisplayName("checkAccount - 존재하지 않는 계정")
+    void checkAccount_AccountNotFound() {
+        // given
+        given(accountRepository.findById(999L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> gcpAlertService.checkAccount(999L))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("GCP 계정을 찾을 수 없습니다");
+    }
+
+    @Test
+    @DisplayName("checkAccount - 리소스 조회 실패 시 빈 리스트 반환")
+    void checkAccount_ResourceFetchFails() {
+        // given
+        given(accountRepository.findById(100L)).willReturn(Optional.of(testAccount));
+        given(resourceService.listResources(anyLong(), anyLong())).willThrow(new RuntimeException("API 오류"));
+        given(ruleLoader.getAllRules()).willReturn(Collections.emptyList());
+
+        // when
+        List<GcpAlert> alerts = gcpAlertService.checkAccount(100L);
+
+        // then
+        assertThat(alerts).isEmpty();
+    }
+}
+

--- a/src/test/java/com/NcpAlertServiceTest.java
+++ b/src/test/java/com/NcpAlertServiceTest.java
@@ -1,0 +1,118 @@
+package com.budgetops.backend.ncp.service;
+
+import com.budgetops.backend.domain.user.entity.Member;
+import com.budgetops.backend.ncp.dto.NcpAlert;
+import com.budgetops.backend.ncp.entity.NcpAccount;
+import com.budgetops.backend.ncp.repository.NcpAccountRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("NcpAlert Service 테스트")
+class NcpAlertServiceTest {
+
+    @Mock
+    private NcpAccountRepository accountRepository;
+
+    @Mock
+    private NcpServerService serverService;
+
+    @Mock
+    private NcpRuleLoader ruleLoader;
+
+    @Mock
+    private NcpMetricService metricService;
+
+    @InjectMocks
+    private NcpAlertService ncpAlertService;
+
+    private NcpAccount testAccount;
+    private Member testMember;
+
+    @BeforeEach
+    void setUp() {
+        testMember = new Member();
+        testMember.setId(1L);
+
+        testAccount = new NcpAccount();
+        testAccount.setId(100L);
+        testAccount.setOwner(testMember);
+        testAccount.setName("Test NCP Account");
+        testAccount.setActive(Boolean.TRUE);
+    }
+
+    @Test
+    @DisplayName("checkAllAccounts - 모든 계정 체크")
+    void checkAllAccounts_Success() {
+        // given
+        given(accountRepository.findAll()).willReturn(List.of(testAccount));
+        given(accountRepository.findById(100L)).willReturn(Optional.of(testAccount));
+        given(serverService.listInstances(anyLong(), anyString())).willReturn(Collections.emptyList());
+        given(ruleLoader.getAllRules()).willReturn(Collections.emptyList());
+
+        // when
+        List<NcpAlert> alerts = ncpAlertService.checkAllAccounts();
+
+        // then
+        assertThat(alerts).isNotNull();
+        verify(accountRepository).findAll();
+    }
+
+    @Test
+    @DisplayName("checkAccount - 존재하지 않는 계정")
+    void checkAccount_AccountNotFound() {
+        // given
+        given(accountRepository.findById(999L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> ncpAlertService.checkAccount(999L))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("NCP 계정을 찾을 수 없습니다");
+    }
+
+    @Test
+    @DisplayName("checkAccount - 비활성화된 계정")
+    void checkAccount_InactiveAccount() {
+        // given
+        testAccount.setActive(Boolean.FALSE);
+        given(accountRepository.findById(100L)).willReturn(Optional.of(testAccount));
+
+        // when
+        List<NcpAlert> alerts = ncpAlertService.checkAccount(100L);
+
+        // then
+        assertThat(alerts).isEmpty();
+    }
+
+    @Test
+    @DisplayName("checkAccount - 서버 조회 실패 시 빈 리스트 반환")
+    void checkAccount_ServerFetchFails() {
+        // given
+        given(accountRepository.findById(100L)).willReturn(Optional.of(testAccount));
+        given(serverService.listInstances(anyLong(), anyString())).willThrow(new RuntimeException("API 오류"));
+        given(ruleLoader.getAllRules()).willReturn(Collections.emptyList());
+
+        // when
+        List<NcpAlert> alerts = ncpAlertService.checkAccount(100L);
+
+        // then
+        assertThat(alerts).isEmpty();
+    }
+}
+


### PR DESCRIPTION
제목  
test: AwsAlertService · GcpAlertService · NcpAlertService · AzureAlertService 테스트 코드 추가 (#144)

## 작업 개요
멀티 클라우드 알림 서비스(AWS/GCP/NCP/Azure) 전반의 핵심 동작을 검증하기 위한 단위 테스트를 추가했습니다.  
각 CSP별 알림 조회 흐름, 계정 단위 처리, 예외 상황 대응 등을 테스트하여, 알림 시스템 전체의 안정성과 예측 가능성을 높였습니다.

## 변경 사항
### AwsAlertService 테스트 추가
- 모든 서비스 알림 체크 성공
- EC2 서비스 체크 실패 시 예외 처리
- 특정 계정 알림 체크
- 알림이 없는 경우 처리

### GcpAlertService 테스트 추가
- 모든 계정 체크 성공
- 존재하지 않는 계정 조회 시 예외
- 리소스 조회 실패 시 빈 리스트 처리

### NcpAlertService 테스트 추가
- 모든 계정 체크 성공
- 존재하지 않는 계정 조회 시 예외
- 비활성화된 계정 처리
- 서버 조회 실패 시 빈 리스트 처리

### AzureAlertService 테스트 추가
- 모든 계정 체크 성공
- 존재하지 않는 계정 조회 시 예외
- 비활성화된 계정 처리
- VM 조회 실패 시 빈 리스트 처리

## 영향 범위
- 알림 서비스 전체의 테스트 커버리지가 확대되어 회귀 방지 능력이 강화됩니다.
- 프로덕션 로직에는 변경이 없으며, 테스트 코드 추가만 이뤄졌습니다.
- CSP별 API 오류 케이스가 명확히 검증되어 차후 알림 로직 수정이 안전해집니다.
