### PR TITLE
feat: 사용자 목록 조회 시 정렬 쿼리 최적화

### DIFF
--- a/src/main/java/com/budgetops/backend/domain/user/repository/MemberRepository.java
+++ b/src/main/java/com/budgetops/backend/domain/user/repository/MemberRepository.java
@@ -4,6 +4,8 @@ import com.budgetops.backend.domain.user.entity.Member;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -22,4 +24,17 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
      * 이름 또는 이메일로 검색 (대소문자 무시)
      */
     Page<Member> findByNameContainingIgnoreCaseOrEmailContainingIgnoreCase(String name, String email, Pageable pageable);
+
+    /**
+     * 전체 조회 (최근 접속일 기준 정렬: null이 아닌 것 우선, 최신순)
+     * null인 것들은 가입일 기준 최신순
+     */
+    @Query("SELECT m FROM Member m ORDER BY CASE WHEN m.lastLoginAt IS NULL THEN 1 ELSE 0 END, m.lastLoginAt DESC NULLS LAST, m.createdAt DESC")
+    Page<Member> findAllOrderByLastLoginAtDesc(Pageable pageable);
+
+    /**
+     * 이름 또는 이메일로 검색 (최근 접속일 기준 정렬)
+     */
+    @Query("SELECT m FROM Member m WHERE LOWER(m.name) LIKE LOWER(CONCAT('%', :search, '%')) OR LOWER(m.email) LIKE LOWER(CONCAT('%', :search, '%')) ORDER BY CASE WHEN m.lastLoginAt IS NULL THEN 1 ELSE 0 END, m.lastLoginAt DESC NULLS LAST, m.createdAt DESC")
+    Page<Member> findByNameContainingIgnoreCaseOrEmailContainingIgnoreCaseOrderByLastLoginAtDesc(@Param("search") String search, Pageable pageable);
 }


### PR DESCRIPTION
- AdminService의 getUserList 메서드에서 사용자 목록 조회 시 정렬 쿼리를 최적화하여 lastLoginAt 기준으로 정렬하도록 수정
- MemberRepository에 lastLoginAt 기준으로 정렬된 전체 조회 및 검색 쿼리 메서드 추가