### PR TITLE
feat: 구독 취소 기능 구현

### DIFF
--- a/src/main/java/com/budgetops/backend/billing/controller/BillingController.java
+++ b/src/main/java/com/budgetops/backend/billing/controller/BillingController.java
@@ -68,4 +68,18 @@ public class BillingController {
 
         return ResponseEntity.ok(BillingResponse.from(billing));
     }
+
+    /**
+     * 구독 취소 (다음 결제일까지 현재 플랜 유지)
+     */
+    @PostMapping("/cancel")
+    public ResponseEntity<BillingResponse> cancelSubscription(@PathVariable Long userId) {
+        Member member = getMemberById(userId);
+        Billing billing = billingService.cancelSubscription(member);
+
+        log.info("구독 취소 완료: userId={}, plan={}, nextBillingDate={}",
+                userId, billing.getCurrentPlan(), billing.getNextBillingDate());
+
+        return ResponseEntity.ok(BillingResponse.from(billing));
+    }
 }

--- a/src/main/java/com/budgetops/backend/billing/dto/response/BillingResponse.java
+++ b/src/main/java/com/budgetops/backend/billing/dto/response/BillingResponse.java
@@ -57,7 +57,7 @@ public class BillingResponse {
                 .nextPaymentDate(billing.getNextBillingDate() != null
                     ? billing.getNextBillingDate().format(DateConstants.DATE_FORMAT)
                     : null)
-                .status("active")
+                .status(billing.getStatus().getValue())  // "active", "canceled", "past_due"
 
                 // 토큰/할당량 정보
                 .currentTokens(billing.getCurrentTokens())

--- a/src/main/java/com/budgetops/backend/billing/entity/Billing.java
+++ b/src/main/java/com/budgetops/backend/billing/entity/Billing.java
@@ -1,6 +1,7 @@
 package com.budgetops.backend.billing.entity;
 
 import com.budgetops.backend.billing.enums.BillingPlan;
+import com.budgetops.backend.billing.enums.SubscriptionStatus;
 import com.budgetops.backend.domain.user.entity.Member;
 import jakarta.persistence.*;
 import lombok.*;
@@ -34,6 +35,11 @@ public class Billing {
     @Column(nullable = false)
     @Builder.Default
     private int currentPrice = 0;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @Builder.Default
+    private SubscriptionStatus status = SubscriptionStatus.ACTIVE;
 
     @Column(name = "next_billing_date")
     private LocalDateTime nextBillingDate;
@@ -94,5 +100,33 @@ public class Billing {
      */
     public void setNextBillingDateFromNow() {
         this.nextBillingDate = LocalDateTime.now().plusMonths(1);
+    }
+
+    /**
+     * 구독 취소 (다음 결제일까지 현재 플랜 유지)
+     */
+    public void cancelSubscription() {
+        this.status = SubscriptionStatus.CANCELED;
+    }
+
+    /**
+     * 구독이 취소되었는지 확인
+     */
+    public boolean isCanceled() {
+        return this.status == SubscriptionStatus.CANCELED;
+    }
+
+    /**
+     * 구독이 활성 상태인지 확인
+     */
+    public boolean isActive() {
+        return this.status == SubscriptionStatus.ACTIVE;
+    }
+
+    /**
+     * 구독 재활성화
+     */
+    public void reactivateSubscription() {
+        this.status = SubscriptionStatus.ACTIVE;
     }
 }

--- a/src/main/java/com/budgetops/backend/billing/enums/SubscriptionStatus.java
+++ b/src/main/java/com/budgetops/backend/billing/enums/SubscriptionStatus.java
@@ -1,0 +1,19 @@
+package com.budgetops.backend.billing.enums;
+
+import lombok.Getter;
+
+/**
+ * 구독 상태
+ */
+@Getter
+public enum SubscriptionStatus {
+    ACTIVE("active"),       // 활성 (자동 결제 진행)
+    CANCELED("canceled"),   // 취소됨 (다음 결제일까지 혜택 유지, 자동 결제 안 함)
+    PAST_DUE("past_due");   // 결제 실패
+
+    private final String value;
+
+    SubscriptionStatus(String value) {
+        this.value = value;
+    }
+}

--- a/src/main/java/com/budgetops/backend/billing/scheduler/BillingScheduler.java
+++ b/src/main/java/com/budgetops/backend/billing/scheduler/BillingScheduler.java
@@ -1,0 +1,35 @@
+package com.budgetops.backend.billing.scheduler;
+
+import com.budgetops.backend.billing.service.BillingService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * 빌링 관련 스케줄러
+ * - 만료된 구독을 FREE 플랜으로 다운그레이드
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class BillingScheduler {
+
+    private final BillingService billingService;
+
+    /**
+     * 매일 자정에 만료된 구독을 FREE 플랜으로 다운그레이드
+     * cron: 초 분 시 일 월 요일
+     * 0 0 0 * * * = 매일 자정
+     */
+    @Scheduled(cron = "0 0 0 * * *")
+    public void downgradeExpiredSubscriptions() {
+        log.info("만료된 구독 다운그레이드 스케줄러 시작");
+        try {
+            billingService.downgradeExpiredSubscriptions();
+            log.info("만료된 구독 다운그레이드 스케줄러 완료");
+        } catch (Exception e) {
+            log.error("만료된 구독 다운그레이드 스케줄러 실패: {}", e.getMessage(), e);
+        }
+    }
+}


### PR DESCRIPTION
- SubscriptionStatus enum 추가 (ACTIVE, CANCELED, PAST_DUE)
- Billing 엔티티에 status 필드 추가
- 구독 취소 API 추가: POST /api/v1/users/{userId}/billing/cancel
- 구독 취소 시 다음 결제일까지 현재 플랜 유지, 자동 결제는 중단
- 만료된 구독을 FREE 플랜으로 다운그레이드하는 스케줄러 추가 (매일 자정)
- BillingResponse에 실제 구독 상태 반영